### PR TITLE
Add gdbtarget launch example

### DIFF
--- a/examples/cpp-debug-workspace/.theia/launch.json
+++ b/examples/cpp-debug-workspace/.theia/launch.json
@@ -7,6 +7,12 @@
             "program": "${workspaceFolder}/build/a",
             "verbose": true,
             "logFile": "/tmp/a.out",
+        },
+        {
+            "name": "cpp local remote",
+            "type": "gdbtarget",
+            "program": "${workspaceFolder}/build/a",
+            "request": "launch"
         }
     ]
 }


### PR DESCRIPTION
Good to have examples. Based on top of #39, which added a new debug adapter that supports this new launch type.