### PR TITLE
Misc Updates (setup tests, update npm scripts, update devDependencies)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ lib
 !*-app/package.json
 examples/cpp-debug-workspace/build/
 yarn.lock
+.nyc_output

--- a/browser-app/package.json
+++ b/browser-app/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "prepare": "theia build --mode development",
     "start": "theia start",
+    "test": "true",
     "watch": "theia build --watch --mode development"
   },
   "theia": {

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "prepare": "theia build --mode development",
     "start": "theia start",
+    "test": "true",
     "watch": "theia build --watch --mode development"
   },
   "theia": {

--- a/package.json
+++ b/package.json
@@ -2,12 +2,21 @@
   "private": true,
   "name": "parent",
   "version": "0.0.0",
+  "engines": {
+    "yarn": "1.0.x || >=1.2.1",
+    "node": ">=10.2.0 <12"
+  },
   "resolution": {
     "**/@types/node": "~10.3.6"
   },
   "devDependencies": {
-    "lerna": "^2.2.0",
+    "@types/chai": "^4.0.1",
+    "@types/mocha": "^2.2.41",
+    "chai": "^4.1.0",
     "concurrently": "^3.5.0",
+    "lerna": "^2.2.0",
+    "mocha": "^3.4.2",
+    "nyc": "^11.0.3",
     "tslint": "^5.12.0"
   },
   "scripts": {
@@ -21,9 +30,11 @@
     "next:publish": "lerna publish --exact --canary=next --npm-tag=next --yes",
     "publish:check": "node scripts/check-publish.js",
     "test": "yarn test:theia && yarn test:electron && yarn test:browser",
-    "test:theia": "true",
-    "test:electron": "/bin/true",
-    "test:browser": "/bin/true"
+    "test:theia": "run test \"@theia/!(example-)*\" --stream --concurrency=1",
+    "test:browser": "run test \"browser-app\"",
+    "test:electron": "run test \"electron-app\"",
+    "start:browser": "theia rebuild:browser && run start \"browser-app\"",
+    "start:electron": "theia rebuild:electron && run start \"electron-app\""
   },
   "workspaces": [
     "packages/*",

--- a/packages/cpp-debug/src/browser/memory-provider.spec.ts
+++ b/packages/cpp-debug/src/browser/memory-provider.spec.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2018 Arm and others.
+ * Copyright (C) 2019 Ericsson and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -16,7 +16,7 @@
 
 import { expect } from 'chai';
 
-describe('cortex-debug', () => {
+describe('cpp-debug', () => {
     it('should pass', () => {
         expect(true).to.equal(true);
     });


### PR DESCRIPTION
**Description**:

- setup repository so that tests can be run (added new scripts, updated dependencies).
- added new `package.json` scripts to run the `browser` or `electron` targets directly from
the root of the repository.
- added the `theia.code-snippets` which adds the license header snippet for new files.
- added example tests (which can later be modified/added).

**How to Test:**
- it should now be possible to run the browser-app from the root of the repo:
(ex: `yarn start:browser` once `yarn` is performed)
- it should now be possible to run the electron-app from the root of the repo:
(ex: `yarn start:electron` once `yarn` is performed)
- it should now be possible to test the application
(ex: `yarn test` from the root of the repo)
- it should now be possible to test the `browser-app`
(ex: `yarn test:browser`)
- it should now be possible to test the `electron-app`
(ex: `yarn test:electron`)
- it should now be possible to add `header` snippets when editing the repo through VSCode

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>