### PR TITLE
Add license header code-snippets

### DIFF
--- a/.vscode/theia.code-snippets
+++ b/.vscode/theia.code-snippets
@@ -1,0 +1,11 @@
+{
+    "Copyright-JS/JSX/TS/TSX/CSS": {
+        "prefix": [
+            "header",
+            "copyright"
+        ],
+        "body": "/********************************************************************************\n * Copyright (C) $CURRENT_YEAR ${YourCompany} and others.\n *\n * This program and the accompanying materials are made available under the\n * terms of the Eclipse Public License v. 2.0 which is available at\n * http://www.eclipse.org/legal/epl-2.0.\n *\n * This Source Code may also be made available under the following Secondary\n * Licenses when the conditions for such availability set forth in the Eclipse\n * Public License v. 2.0 are satisfied: GNU General Public License, version 2\n * with the GNU Classpath Exception which is available at\n * https://www.gnu.org/software/classpath/license.html.\n *\n * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0\n ********************************************************************************/\n\n$0",
+        "description": "Adds the copyright...",
+        "scope": "javascript,javascriptreact,typescript,typescriptreact,css"
+    }
+}


### PR DESCRIPTION
**Description**

Added `theia.code-snippets` which easily add license headers for files when developing with VSCode. The `tslint` check verifying for license headers in each file compliment this feature.

**How to Test**

_Testing the `code-snippet`_:

1. use VSCode to develop
2. create a new Typescript file under either extension (`cortex-debug` or `cpp-debug`)
3. start typing `header` and select the first snippet
4. the license header should be automatically added and the cursor should be set to the company for easy editing.
 
_Testing the check_:

1. create a new Typescript file in either extension (`cortex-debug` or `cpp-debug`)
2. do not add a license header
3. build the application, there should be a failure expressing a missing license header present.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>