### PR TITLE
[built-ins] get extensions from open-vsx.org

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,11 +64,11 @@
   },
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {
-    "vscode-builtin-cpp": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/cpp-1.39.1-prel.vsix",
-    "vscode-builtin-json": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/json-1.39.1-prel.vsix",
-    "vscode-builtin-markdown": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/markdown-1.39.1-prel.vsix",
-    "vscode-builtin-npm": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/npm-1.39.1-prel.vsix",
-    "vscode-builtin-typescript": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/typescript-1.39.1-prel.vsix",
-    "vscode-builtin-typescript-language-features": "https://github.com/theia-ide/vscode-builtin-extensions/releases/download/v1.39.1-prel/typescript-language-features-1.39.1-prel.vsix"
+    "vscode-builtin-cpp": "https://open-vsx.org/api/vscode/cpp/1.43.2/file/vscode.cpp-1.43.2.vsix",
+    "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.39.1/file/vscode.json-1.39.1.vsix",
+    "vscode-builtin-markdown": "https://open-vsx.org/api/vscode/markdown/1.39.1/file/vscode.markdown-1.39.1.vsix",
+    "vscode-builtin-npm": "https://open-vsx.org/api/vscode/npm/1.39.1/file/vscode.npm-1.39.1.vsix",
+    "vscode-builtin-typescript": "https://open-vsx.org/api/vscode/typescript/1.39.1/file/vscode.typescript-1.39.1.vsix",
+    "vscode-builtin-typescript-language-features": "https://open-vsx.org/api/vscode/typescript-language-features/1.39.1/file/vscode.typescript-language-features-1.39.1.vsix"
   }
 }


### PR DESCRIPTION
#### What it does
This PR changes the place where we download the built-in VS Code extensions. Instead of using a GH release we use the new open-vsx.org. The URL used should be stable and continue to work after new versions are released (we'll need to update the URL to get new versions eventually. 

#### How to test
Validate that the example app still works and that the expected extensions are fetched, by looking at the content of the `plugins` folder.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
