### PR TITLE
[CI] Fix publish of 'next'

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -70,6 +70,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Pre-Publish 
         shell: bash
@@ -82,7 +83,7 @@ jobs:
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 5
-          retry_wait_seconds: 30
+          retry_wait_seconds: 60
           max_attempts: 3
           retry_on: error
           command: yarn run publish:next

--- a/scripts/check-publish.js
+++ b/scripts/check-publish.js
@@ -20,7 +20,7 @@ const chalk = require('chalk').default;
 const cp = require('child_process');
 
 let code = 0;
-const workspaces = JSON.parse(JSON.parse(cp.execSync('yarn workspaces info --json').toString()).data);
+const workspaces = JSON.parse(cp.execSync('yarn --silent workspaces info').toString());
 for (const name in workspaces) {
     const workspace = workspaces[name];
     const location = path.resolve(process.cwd(), workspace.location);


### PR DESCRIPTION
A change from upstream, in check-publish.sh was needed to avoid
a race-condition that made this check fail randomly. Also it seems
we need to specify the npm registry to publish.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
