### PR TITLE
Fix theiaPlugins dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,12 +56,12 @@
   ],
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {
-    "vscode-builtin-cpp": "https://open-vsx.org/api/vscode/cpp/1.43.2/file/vscode.cpp-1.43.2.vsix",
-    "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.39.1/file/vscode.json-1.39.1.vsix",
-    "vscode-builtin-markdown": "https://open-vsx.org/api/vscode/markdown/1.39.1/file/vscode.markdown-1.39.1.vsix",
-    "vscode-builtin-npm": "https://open-vsx.org/api/vscode/npm/1.39.1/file/vscode.npm-1.39.1.vsix",
-    "vscode-builtin-typescript": "https://open-vsx.org/api/vscode/typescript/1.39.1/file/vscode.typescript-1.39.1.vsix",
-    "vscode-builtin-typescript-language-features": "https://open-vsx.org/api/vscode/typescript-language-features/1.39.1/file/vscode.typescript-language-features-1.39.1.vsix",
-    "vscode-clangd": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.1.5/file/llvm-vs-code-extensions.vscode-clangd-0.1.5.vsix"
+    "vscode-builtin-cpp": "https://open-vsx.org/api/vscode/cpp/1.52.1/file/vscode.cpp-1.52.1.vsix",
+    "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.52.1/file/vscode.json-1.52.1.vsix",
+    "vscode-builtin-markdown": "https://open-vsx.org/api/vscode/markdown/1.52.1/file/vscode.markdown-1.52.1.vsix",
+    "vscode-builtin-npm": "https://open-vsx.org/api/vscode/npm/1.52.1/file/vscode.npm-1.52.1.vsix",
+    "vscode-builtin-typescript": "https://open-vsx.org/api/vscode/typescript/1.52.1/file/vscode.typescript-1.52.1.vsix",
+    "vscode-builtin-typescript-language-features": "https://open-vsx.org/api/vscode/typescript-language-features/1.52.1/file/vscode.typescript-language-features-1.52.1.vsix",
+    "vscode-clangd": "https://open-vsx.org/api/llvm-vs-code-extensions/vscode-clangd/0.1.7/file/llvm-vs-code-extensions.vscode-clangd-0.1.7.vsix"
   }
 }


### PR DESCRIPTION
It seems that open-vsx.org removes the old dependencies, so we can no longer build the theia application anymore.
This fix updates the dependences to the latest one according to their open-vsx pages.

#### What it does
Change the links of theia plugins to their latest version on open-vsx.

#### How to test
Build with `yarn` and wait.

#### Review checklist
- [x]  as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
