### PR TITLE
Fixed memory editing

### DIFF
--- a/packages/cpp-debug/src/browser/editable-widget/memory-editable-table-widget.tsx
+++ b/packages/cpp-debug/src/browser/editable-widget/memory-editable-table-widget.tsx
@@ -153,8 +153,7 @@ export class MemoryEditableTableWidget extends MemoryTableWidget {
         const offset = addressPlusArrayOffset.subtract(this.memory.address);
         const chunksPerByte = this.options.byteSize / 8;
         const startingChunkIndex = offset.subtract(offset.modulo(chunksPerByte));
-        const address = this.memory.address.add(startingChunkIndex.multiply(8 / this.options.byteSize));
-
+        const address = this.memory.address.add(startingChunkIndex.divide(chunksPerByte));
         for (let i = 0; i < chunksPerByte; i += 1) {
             const targetOffset = startingChunkIndex.add(i);
             const targetChunk = this.getFromMapOrArray(targetOffset, usePendingEdits, dataSource);
@@ -184,26 +183,31 @@ export class MemoryEditableTableWidget extends MemoryTableWidget {
     }
 
     protected submitMemoryEdits = async (): Promise<void> => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for await (const _ of this.submitMemoryEditInOrder()) {
-            // Do nothing, but without lint errors.
-        }
-    };
-
-    private * submitMemoryEditInOrder(): IterableIterator<Promise<DebugProtocol.WriteMemoryResponse | undefined>> {
         this.memoryEditsCompleted = new Deferred();
-        const addressesSubmitted = new Set<Long>();
-        for (const k of this.pendingMemoryEdits.keys()) {
-            const address = Long.fromString(k);
-            const { address: addressToSend, value: valueToSend } = this.composeByte(address, true);
-            if (!addressesSubmitted.has(addressToSend)) {
-                const data = Buffer.from(valueToSend, 'hex').toString('base64');
-                const writeMemoryArguments = { memoryReference: addressToSend.toString(), data };
-                yield this.memoryProvider.writeMemory?.(writeMemoryArguments) ?? Promise.resolve(undefined);
-                addressesSubmitted.add(addressToSend);
+        for (const edit of this.createUniqueEdits()) {
+            try {
+                await this.memoryProvider.writeMemory(edit);
+            } catch (e) {
+                console.log('Problem writing memory with arguments', edit, '\n', e);
             }
         }
         this.memoryEditsCompleted.resolve();
+    };
+
+    private createUniqueEdits(): Array<DebugProtocol.WriteMemoryArguments> {
+        const addressesSubmitted = new Set<string>();
+        const edits = [];
+        for (const k of this.pendingMemoryEdits.keys()) {
+            const address = Long.fromString(k);
+            const { address: addressToSend, value: valueToSend } = this.composeByte(address, true);
+            const memoryReference = '0x' + addressToSend.toString(16);
+            if (!addressesSubmitted.has(memoryReference)) {
+                const data = Buffer.from(valueToSend, 'hex').toString('base64');
+                edits.push({ memoryReference, data });
+                addressesSubmitted.add(memoryReference);
+            }
+        }
+        return edits;
     }
 
     protected getWrapperHandlers(): MemoryTable.WrapperHandlers {

--- a/packages/cpp-debug/src/browser/memory-widget/memory-table-widget.tsx
+++ b/packages/cpp-debug/src/browser/memory-widget/memory-table-widget.tsx
@@ -30,6 +30,7 @@ import { MemoryHoverRendererService, EasilyMappedObject } from '../utils/memory-
 import { VariableDecoration, VariableFinder } from '../utils/memory-widget-variable-utils';
 import { MWMoreMemorySelect } from '../utils/memory-widget-components';
 import { MemoryProviderService } from '../memory-provider/memory-provider-service';
+import { hexStrToUnsignedLong } from '../../common/util';
 
 /* eslint-disable @typescript-eslint/no-explicit-any,no-bitwise,react/destructuring-assignment */
 export namespace MemoryTable {
@@ -612,7 +613,7 @@ export class MemoryTableWidget extends ReactWidget {
         const args: any[] = [this];
         const id = (event.target as HTMLElement).getAttribute('data-id');
         if (id) {
-            const location = parseInt(id);
+            const location = hexStrToUnsignedLong(id);
             args.push(location);
             const offset = this.memory.address.multiply(-1).add(location);
             const cellAddress = this.memory.address.add(offset.multiply(8 / this.options.byteSize));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This fixes the memory editing. The problem seems to come from some incorrect usage of variables of type `Long`. In short `Long` variables cannot be compared using `===` and cannot be used as key in a `Map`.

This fixes #124 .

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
An `EditableMemoryWidget` needs to be created. After that a working backend managing the `writeMemory` request needs to exist.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
