### PR TITLE
Fixed ASCII white-space wrapping

### DIFF
--- a/packages/cpp-debug/src/browser/style/index.css
+++ b/packages/cpp-debug/src/browser/style/index.css
@@ -364,6 +364,7 @@ table.t-mv-view td,
 table.t-mv-view th {
     font-family: monospace;
     padding-right: 15px;
+    white-space: pre;
 }
 
 table.t-mv-view .t-mv-view-row.t-mv-view-row-highlight {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This fixes the white space wrapping of the ASCII column.

![image](https://user-images.githubusercontent.com/8626576/132376354-3ddf898d-3608-43d8-a0d5-ebd42447e3b5.png)


It fixes #126 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
A character with a `space` needs to be returned in a position different than the last one of the row. The ASCII column should then be different.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
