### PR TITLE
Cleanup buffer utilities and request

### DIFF
--- a/packages/cpp-debug/package.json
+++ b/packages/cpp-debug/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@theia/core": "1.17.2",
     "@theia/debug": "1.17.2",
-    "base64-arraybuffer": "0.1.5",
     "long": "^4.0.0",
     "vscode-debugprotocol": "^1.48.0"
   },

--- a/packages/cpp-debug/src/browser/editable-widget/memory-editable-table-widget.tsx
+++ b/packages/cpp-debug/src/browser/editable-widget/memory-editable-table-widget.tsx
@@ -25,7 +25,6 @@ import * as Long from 'long';
 import { hexStrToUnsignedLong } from '../../common/util';
 import { MemoryWidget } from '../memory-widget/memory-widget';
 import { MemoryOptionsWidget } from '../memory-widget/memory-options-widget';
-import * as Array64 from 'base64-arraybuffer';
 import { DebugProtocol } from 'vscode-debugprotocol';
 
 export type EditableMemoryWidget = MemoryWidget<MemoryOptionsWidget, MemoryEditableTableWidget>;
@@ -197,7 +196,7 @@ export class MemoryEditableTableWidget extends MemoryTableWidget {
         for (const address of this.pendingMemoryEdits.keys()) {
             const { address: addressToSend, value: valueToSend } = this.composeByte(address, true);
             if (!addressesSubmitted.has(addressToSend)) {
-                const data = Array64.encode(new Uint8Array([parseInt(valueToSend, 16)]));
+                const data = Buffer.from(valueToSend, 'hex').toString('base64');
                 const writeMemoryArguments = { memoryReference: addressToSend.toString(), data };
                 yield this.memoryProvider.writeMemory?.(writeMemoryArguments) ?? Promise.resolve(undefined);
                 addressesSubmitted.add(addressToSend);

--- a/packages/cpp-debug/src/browser/memory-provider/cdt-gdb-memory-provider.ts
+++ b/packages/cpp-debug/src/browser/memory-provider/cdt-gdb-memory-provider.ts
@@ -25,15 +25,7 @@ import { DebugProtocol } from 'vscode-debugprotocol';
  * Convert a hex-encoded string of bytes to the Uint8Array equivalent.
  */
 export function hex2bytes(hex: string): Interfaces.LabeledUint8Array {
-    const arr: Interfaces.LabeledUint8Array = new Uint8Array(hex.length / 2);
-
-    for (let i = 0; i < hex.length / 2; i++) {
-        const hexByte = hex.slice(i * 2, i * 2 + 2);
-        const byte = parseInt(hexByte, 16);
-        arr[i] = byte;
-    }
-
-    return arr;
+    return Buffer.from(hex, 'hex');
 }
 
 /**
@@ -48,7 +40,6 @@ export class CDTGDBMemoryProvider implements MemoryProvider {
     }
 
     async readMemory(session: DebugSession, readMemoryArguments: DebugProtocol.ReadMemoryArguments): Promise<Interfaces.MemoryReadResult> {
-        // @ts-ignore /* Theia 1.17.0 will include the readMemoryRequest in its types. Until then, we can send the request anyway */
         const result = await session.sendRequest('readMemory', readMemoryArguments) as DebugProtocol.ReadMemoryResponse;
 
         if (result.body?.data) {

--- a/packages/cpp-debug/src/browser/memory-provider/memory-provider.ts
+++ b/packages/cpp-debug/src/browser/memory-provider/memory-provider.ts
@@ -17,7 +17,6 @@
 import { Interfaces } from '../utils/memory-widget-utils';
 import { injectable } from '@theia/core/shared/inversify';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import * as Array64 from 'base64-arraybuffer';
 import Long = require('long');
 import { DebugSession } from '@theia/debug/lib/browser/debug-session';
 
@@ -44,7 +43,7 @@ export interface MemoryProvider {
  * Convert a base64-encoded string of bytes to the Uint8Array equivalent.
  */
 export function base64ToBytes(base64: string): Interfaces.LabeledUint8Array {
-    return new Uint8Array(Array64.decode(base64));
+    return Buffer.from(base64, 'base64');
 }
 
 @injectable()
@@ -55,7 +54,6 @@ export class DefaultMemoryProvider implements MemoryProvider {
     }
 
     async readMemory(session: DebugSession, readMemoryArguments: DebugProtocol.ReadMemoryArguments): Promise<Interfaces.MemoryReadResult> {
-        // @ts-ignore /* Theia 1.17.0 will include the readMemoryRequest in its types. Until then, we can send the request anyway */
         const result = await session.sendRequest('readMemory', readMemoryArguments) as DebugProtocol.ReadMemoryResponse;
 
         if (result.body?.data) {
@@ -68,7 +66,6 @@ export class DefaultMemoryProvider implements MemoryProvider {
     }
 
     async writeMemory(session: DebugSession, writeMemoryArguments: DebugProtocol.WriteMemoryArguments): Promise<DebugProtocol.WriteMemoryResponse> {
-        // @ts-ignore /* Theia 1.17.0 will include the writeMemoryRequest in its types. Until then, we can send the request anyway */
-        return session.sendCustomRequest('writeMemory', writeMemoryArguments) as DebugProtocol.WriteMemoryResponse;
+        return session.sendRequest('writeMemory', writeMemoryArguments);
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3583,7 +3583,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-arraybuffer@0.1.5, base64-arraybuffer@^0.1.5:
+base64-arraybuffer@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
   integrity sha1-c5JncZI7Whl0etZmqlzUv5xunOg=


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

This PR cleans up some cruft from various sources:
 - It turns out that the native `Buffer` object can handle the translations that were previously done manually or using a utility library.
 - We've updated to Theia 1.17, so we no longer need the `@ts-ignore` comments
 - `sendCustomRequest` should always have been `sendRequest` in the `DefaultMemoryProvider`

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. This shouldn't affect any existing functionality.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>