### PR TITLE
Load more memory only on Enter

### DIFF
--- a/packages/cpp-debug/src/browser/utils/memory-widget-components.tsx
+++ b/packages/cpp-debug/src/browser/utils/memory-widget-components.tsx
@@ -14,6 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
+import { Key, KeyCode } from '@theia/core/lib/browser';
 import * as React from '@theia/core/shared/react';
 import { Interfaces } from './memory-widget-utils';
 
@@ -156,12 +157,16 @@ export const MWMoreMemorySelect: React.FC<MoreMemoryProps> = ({ options, handler
         const { value } = e.currentTarget;
         setNumBytes(parseInt(value));
     };
-    const loadMoreMemory = (_e: React.MouseEvent | React.KeyboardEvent): void => {
+
+    const loadMoreMemory = (e: React.MouseEvent | React.KeyboardEvent): void => {
         containerRef.current?.blur();
-        handler({
-            numBytes,
-            direction,
-        });
+        const doHandle = !('key' in e) || KeyCode.createKeyCode(e.nativeEvent).key?.keyCode === Key.ENTER.keyCode;
+        if (doHandle) {
+            handler({
+                numBytes,
+                direction,
+            });
+        }
     };
 
     return (


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR fixes an unexpected keyboard interaction in the 'load more memory above / below' component.

Previously, if you tabbed into that component and then tabbed out, more memory would be loaded. Now more memory will only be loaded if you hit 'Enter' while focused on the component, or if you click on it.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Reproduction
1. Load some memory
2. Click on the table
3. Use <kbd>Tab</kbd> to focus the components to load more memory above or below.
4. Use <kbd>Tab</kbd> to shift focus away from the load more memory component.
5. Observe that more memory is loaded (or an attempt is made to load more memory)

## Fix
1. Follow steps 1-4 above.
2. Observe that no attempt is made to load more memory.
3. <kbd>Tab</kbd> back onto the load more memory component.
4. Hit <kbd>Enter</kbd>.
5. Observe that more memory is loaded.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

Signed-off-by: Colin Grant <colin.grant@ericsson.com>