### PR TITLE
Improved cursor look

### DIFF
--- a/packages/cpp-debug/src/browser/editable-widget/memory-editable-table-widget.tsx
+++ b/packages/cpp-debug/src/browser/editable-widget/memory-editable-table-widget.tsx
@@ -46,6 +46,7 @@ export class MemoryEditableTableWidget extends MemoryTableWidget {
     protected async init(): Promise<void> {
         this.memoryEditsCompleted.resolve();
         await super.init();
+        this.addClass('editable');
     }
 
     resetModifiedValue(valueAddress: Long): void {

--- a/packages/cpp-debug/src/browser/style/index.css
+++ b/packages/cpp-debug/src/browser/style/index.css
@@ -721,3 +721,20 @@ table.t-mv-view .t-mv-view-address {
     grid-template-columns: repeat(2, 1fr) 30px;
     grid-template-rows: 18px 24px;
 }
+
+#memory-table-widget.editable .t-mv-view .eight-bits:hover {
+    cursor: pointer;
+}
+
+#memory-table-widget.editable .t-mv-memory-container:focus .eight-bits.highlight {
+    cursor: text;
+}
+
+.diff-options-widget .memory-widget-header-click-zone,
+.diff-options-widget .toggle-settings-click-zone,
+#memory-layout-widget .memory-widget-header-click-zone,
+#memory-layout-widget .toggle-settings-click-zone,
+#memory-layout-widget .fa-unlock,
+#memory-layout-widget .fa-lock {
+    cursor: pointer;
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR improves the cursor look for the memory inspector. On some clickable elements the cursor didn't appear as `pointer` or `text` despite the element being clickable or editable.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Bring the mouse to hover over:
- settings (open and close)
- lock/unlock
- edit memory tab name
- editable memory data cells
- highlighted memory data cells

The appropriate cursor should be shown.

I'm also adding a GIF to show this

![mem-view-pointer](https://user-images.githubusercontent.com/8626576/138062684-2ca7d749-f73e-4338-8e76-028e66fd8793.gif)

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
