### PR TITLE
repo: update `1.18.4`

### DIFF
--- a/dev-packages/eslint-plugin/package.json
+++ b/dev-packages/eslint-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@theia/eslint-plugin",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "description": "Custom ESLint rules for developing Theia extensions and applications",
   "dependencies": {
     "@theia/core": "1.18.0"

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@cpp-debug/example-browser",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "theia": {
     "frontend": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@theia/core": "1.18.0",
-    "@theia/cpp-debug": "1.18.3",
+    "@theia/cpp-debug": "1.18.4",
     "@theia/editor": "1.18.0",
     "@theia/file-search": "1.18.0",
     "@theia/filesystem": "1.18.0",

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@cpp-debug/example-electron",
   "productName": "Theia CPP Extensions Electron Example",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "main": "src-gen/frontend/electron-main.js",
   "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
   "theia": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@theia/core": "1.18.0",
-    "@theia/cpp-debug": "1.18.3",
+    "@theia/cpp-debug": "1.18.4",
     "@theia/editor": "1.18.0",
     "@theia/electron": "1.18.0",
     "@theia/file-search": "1.18.0",

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "lerna": "3.13.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "1.18.3",
+  "version": "1.18.4",
   "command": {
     "run": {
       "stream": true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@theia/cli": "1.18.0",
-    "@theia/eslint-plugin": "1.18.3",
+    "@theia/eslint-plugin": "1.18.4",
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/eslint-plugin-tslint": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",

--- a/packages/cpp-debug/package.json
+++ b/packages/cpp-debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theia/cpp-debug",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "description": "Theia - C/C++ Debug Extension",
   "dependencies": {
     "@theia/core": "1.18.0",


### PR DESCRIPTION
**Description**

The commit updates the versions present in the repository to point to the latest release at `1.18.4` for `cpp-debug`.

Note: sorry about all the noise, there was quite a bit of difficulty publishing the repo with `lerna` given the unique setup.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>
