### PR TITLE
Add a library for configuration of clangd contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ examples/*/gen-webpack.config.js
 examples/*/.theia
 examples/*/.vscode
 examples/*/.test
+examples/*/*.vsix
 .browser_modules
 **/docs/api
 package-backup.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,8 @@
   // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
   // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "davidanson.vscode-markdownlint"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -66,5 +66,21 @@
             "*": "${webRoot}/*"
           }
         },
+        {
+            "name": "Launch Clangd Contexts Example Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "${workspaceFolder}/examples/clangd-workspace",
+                "--extensionDevelopmentPath=${workspaceRoot}/examples/clangd-contexts-ext"
+            ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceRoot}/packages/**/lib/**/*.js",
+                "${workspaceRoot}/examples/**/lib/**/*.js"
+            ]
+        },
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,4 +58,11 @@
   "editor.rulers": [
     180
   ], // ESLint `max-len` rule.
+  "markdownlint.config": {
+    "default": true,
+    "MD007": {
+      "indent": 4
+    },
+    "MD030": false
+  },
 }

--- a/README.md
+++ b/README.md
@@ -18,37 +18,95 @@
 </div>
 
 ## Overview
-Collection of Theia extensions related to C/C++ development.
+
+Collection of Theia extensions, APIs, and other tools related to C/C++ development.
 
 ## Features
+
 - `@theia/cpp-debug`:
-   - Debugging support using `GDB` through the `cdt-gdb-vscode` extension.
-   - Memory view (monitor process memory during debug sessions).
-- `@theia/cpp` **deprecated** and **removed** ([past sources](https://github.com/eclipse-theia/theia-cpp-extensions/tree/184f7751f13e1ec021ccae3f076915867168d28d/packages/cpp)): 
-   - **Deprecated** C/C++ language-features extension.\
-   (Language-features should instead be contributed by VS Code extensions).
+    - Debugging support using `GDB` through the `cdt-gdb-vscode` extension.
+    - Memory view (monitor process memory during debug sessions).
+    - See the [package readme][cdbg] for further details.
+- `@theia/clangd-contexts`:
+    - Library for management of [clangd][clangd] configuration files
+    - Retrieve and set contexts in one or more `.clangd` files
+    - Manage compile flags in `.clangd` files
+    - See the [package readme][cclib] for further details.
+- `@theia/clangd-contexts-cli`
+    - An example command-line tool (`clangd-context`) built on the `@theia/clangd-contexts` API for management of [clangd][clangd] configuration files in C/C++ projects.
+    - See the [package readme][cccli] for details, including a step-by-step guide to the CLI.
+- `theia-clangd-contexts-ext`
+    - An example VS Code extension demonstrating use of the `@theia/clangd-contexts` API.
+    - See the [package readme][ccvsx] for details, including a step-by-step guide to the extension UI.
+- `@theia/cpp` **deprecated** and **removed** ([past sources][cpp]):
+    - **Deprecated** C/C++ language-features extension.\
+        (Language-features should instead be contributed by VS Code extensions).
+
+[cdbg]: ./packages/cpp-debug/README.md
+[cclib]: ./packages/clangd-contexts/README.md
+[cccli]: ./examples/clangd-contexts-cli/README.md
+[ccvsx]: ./examples/clangd-contexts-ext/README.md
+[cpp]: https://github.com/eclipse-theia/theia-cpp-extensions/tree/184f7751f13e1ec021ccae3f076915867168d28d/packages/cpp
+[clangd]: https://clangd.llvm.org
 
 ## How to build
+
+### Packages and Examples
+
+To build the monorepo:
+
+```bash
+$ yarn
+```
+
+Additionally, to make the `clangd-context` example CLI tool available in your C/C++ projects
+(such as the [clangd workspace](#example-workspaces) example):
+
+```bash
+$ cd examples/clangd-contexts-cli
+$ yarn link
+```
+
+> **Note** that on some Linux installations you may need to ensure that Yarn's global bin directory is in your shell path:
+
+```bash
+    $ export PATH=$(yarn global bin):$PATH
+```
+
+### Example Theia Deployments
+
 The `browser-app` and `electron-app` directories contain examples of Theia-based applications which use the extensions
 provided by the repository.
 
 - `browser-app` build instructions:
-  ```bash
-  $ yarn
-  $ yarn rebuild:browser
-  $ cd browser-app && yarn start
-  ```
+
+    ```bash
+    $ yarn
+    $ yarn start:browser
+    ```
 
 - `electron-app` build instructions:
-   ```bash
-   $ yarn
-   $ yarn rebuild:electron
-   $ cd electron-app && yarn start
-   ```
+    ```bash
+    $ yarn
+    $ yarn start:electron
+    ```
+
+## Example Packages
+
+- [`clangd-contexts-cli`][cccli]
+    - provides a command-line tool that demonstrates usage of the clangd contexts API
+- [`clangd-contexts-ext`][ccvsx]
+    - an example VS Code extension that demonstrates usage of the clangd contexts API
 
 ## Example Workspaces
-- [`cpp-debug-workspace`](./examples/cpp-debug-workspace/README.md)
+
+- [`cpp-debug-workspace`][cdbgws]
     - provides an easy and reproducible way to test the functionality present in the `@theia/cpp-debug` extension. Includes a simple C/C++ program, debug launch configuration file (`launch.json`), and a task in order to compile the program (`tasks.json`).
+- [`clangd-workspace`][ccws]
+    - provides a test playground for the `clangd-context` example CLI tool and the API, including the separate [VS Code extension example](./examples/clangd-contexts-ext/README.md)
+
+[cdbgws]: ./examples/cpp-debug-workspace/README.md
+[ccws]: ./examples/clangd-workspace/README.md
 
 ## License
 
@@ -56,5 +114,6 @@ provided by the repository.
 - [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
 
 ## Trademark
-"Theia" is a trademark of the Eclipse Foundation
+
+"Theia" is a trademark of the Eclipse Foundation  
 https://www.eclipse.org/theia

--- a/configs/mocha.opts
+++ b/configs/mocha.opts
@@ -1,5 +1,0 @@
---require ignore-styles
---require reflect-metadata/Reflect
---reporter spec
---watch-extensions js
---exit

--- a/configs/mocharc.json
+++ b/configs/mocharc.json
@@ -1,0 +1,9 @@
+{
+  "require": [
+    "ignore-styles",
+    "reflect-metadata/Reflect"
+  ],
+  "reporter": "spec",
+  "watchExtensions": "js",
+  "exit": true
+}

--- a/configs/root-compilation.tsconfig.json
+++ b/configs/root-compilation.tsconfig.json
@@ -12,6 +12,15 @@
     },
     {
       "path": "../packages/cpp-debug/compile.tsconfig.json"
+    },
+    {
+      "path": "../packages/clangd-contexts/compile.tsconfig.json"
+    },
+    {
+      "path": "../examples/clangd-contexts-cli/compile.tsconfig.json"
+    },
+    {
+      "path": "../examples/clangd-contexts-ext/compile.tsconfig.json"
     }
   ]
 }

--- a/examples/clangd-contexts-cli/.eslintrc.js
+++ b/examples/clangd-contexts-cli/.eslintrc.js
@@ -1,0 +1,11 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json',
+        './overrides.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'compile.tsconfig.json'
+    }
+};

--- a/examples/clangd-contexts-cli/README.md
+++ b/examples/clangd-contexts-cli/README.md
@@ -1,0 +1,246 @@
+# @theia/clangd-contexts-cli
+
+## Overview
+
+A CLI tool for management of [clangd](https://clangd.llvm.org) configuration files in C/C++ projects.
+
+## Features
+
+-   identify multiple different projects in a C/C++ workspace edited with clangd support
+-   quickly and easily apply clangd contexts, described by `compile_commands.json` files, to projects
+-   customize the invocation of `clang` by clangd on a per project basis to account for differences between `clang` and the project's C/C++ toolchain
+
+## CLI Usage
+
+The _clangd contexts_ CLI application provides several commands to interact with the context API.
+It can be used to set the clangd context for a given project directory and retrieve the clangd context for a given project.
+In addition, the CLI provides commands to change the set of compilation flags that should be considered by the clangd server for a given project configuration (`.clangd` file).
+
+> **Note** that in order to run the `clangd-context` CLI tool as shown in these snippets, you need to link the `@theia/clangd-contexts-cli` package with "`yarn link`".
+
+Once the `clangd-contexts` project has been built and the CLI linked as described in the [root README file](../../README.md#how-to-build), the command is available to execute in a VScode terminal as shown here.
+The main help output of the CLI application looks like this:
+
+```console
+$ clangd-context
+Usage: clangd-context [options] [command]
+
+Options:
+  -h, --help      display help for command
+
+Commands:
+  get-context     get the context in a project configuration
+  set-context     set or change the context in a project configuration
+  list            list the projects in the clangd workspace
+  list-contexts   list the contexts of the projects in the clangd workspace
+  select-context  select a context to activate in every project in the workspace
+  set-flags       set added/removed compile flags in a project
+  unset-flags     unset added/removed compile flags in a project
+  help [command]  display help for command
+```
+
+The `select-contexts` command requires knowledge of what the clangd contexts in the current workspace scope are.
+This scope is defined by an optional `.clangd-contexts` file.
+
+### Workspace Clangd Contexts Configuration
+
+A workspace may optionally provide a `.clangd-contexts` file that tells the CLI the layout of projects in the workspace.
+It indicates which directories comprise projects, configured by `.clangd` files and how to find context directories containing the `compile_commands.json` files in each project.
+A workspace may contain any number of `.clangd-contexts` files that each describe the layout of their distinct subtree.
+
+The `.clangd-contexts` file is a JSON object that looks like this example from the [Example Clangd Contexts Workspace](../clangd-workspace/README.md):
+
+```json
+{
+    "workspaceName": "Theia Clangd Contexts Example",
+    "projects": [
+        {
+            "path": "app",
+            "contextDirs": "flat"
+        },
+        {
+            "path": "lib",
+            "contextDirs": "flat"
+        }
+    ]
+}
+```
+
+An optional name identifies the workspace but is not used by the CLI. The list of clangd `projects` specifies for each:
+
+-   the path to the project directory, relative to the workspace root (which is the directory containing the `.clangd-contexts` file). This directory must contain the context directories (and therefore the `compile_commands.json` files) but is not required to contain the source files
+-   the shape of context directories in the context, either `"flat"` or `"nested"`. This tells the CLI how to search for the `compile_commands.json` files that describe each context and how to derive context names
+    -   in the flat scheme, the context name is just the name of the directory containing the `compile_commands.json` file
+    -   in the nested scheme, the context name is the slash-separated path of the directory containing the `compile_commands.json` file, relative to the project directory
+
+For commands that use this workspace configuration file, the CLI searches up the directory hierarchy from the current working directory.
+The workspace scope is the directory tree rooted in the directory in which the `.clangd-contexts` file is found.
+
+### Getting a Context
+
+If you haven't already, prepare the `clangd-workspace` example workspace by [building it](../clangd-workspace/README.md#how-to-build-the-workspace).
+
+First retrieve the current context configuration of the `app` project.
+This can be done with the `get-context` command.
+This command takes the location of a `.clangd` configuration file or its parent directory as input.
+There should not be any `.clangd` file in the `app/` directory yet so the expected output is:
+
+```console
+$ clangd-context get-context app
+{ name: 'NO_CONTEXT', compilationDatabase: '' }
+```
+
+### Setting a Context
+
+Next, set the active clangd context.
+The `app/` and `lib/` projects both contain two contexts `Debug_x86-64` and `Release_Atom`.
+Set a context with the `set-context` command.
+As for the `get-context` command, the main argument is the location of the `.clangd` configuration file or its parent directory.
+It is also necessary to specify the compilation database (`compile_commands.json` file or its parent directory) to identify the context to set in the project.
+This is done with the `--compile-commands` (`-c`) option:
+
+```console
+clangd-context set-context -c app/Debug_x86-64 app
+```
+
+Now the `app/` directory should contain a new `.clangd` file with the following contents:
+
+```yaml
+CompileFlags:
+    CompilationDatabase: /home/me/git/theia-cpp-extensions/examples/clangd-workspace/app/Debug_x86-64
+```
+
+Upon executing the previous `get-context` command again, the output should be as follows:
+
+```console
+$ clangd-context get-context app
+{
+  name: 'Debug_x86-64',
+  compilationDatabase: '/home/me/git/theia-cpp-extensions/examples/clangd-workspace/app/Debug_x86-64'
+}
+```
+
+With this configuration file the clangd server now has all of the information it needs to provide language support for the `Debug_x86-64` context.
+
+### Listing the Projects in the Workspace
+
+For workspaces that are configured with a `.clangd-contexts` file, the CLI supports an additional command `list` that lists the configured projects.
+For example, executing the following command in the example workspace:
+
+```console
+$ clangd-context list
+app/
+lib/
+```
+
+results in the paths of existing clangd contexts being displayed relative to the current working directory.
+
+### Listing the Clangd Contexts in the Workspace
+
+For workspaces that are configured with a `.clangd-contexts` file, the CLI supports an additional command `list-contexts` that lists the available context names across all projects in the workspace.
+For example, executing the following command in the example workspace:
+
+```console
+$ clangd-context list-contexts
+Debug_x86-64
+Release_Atom
+```
+
+shows that across all projects in the workspace, the unique context names are `Debug_x86-64` and `Release_Atom`.
+
+### Selecting a Context for the Workspace
+
+For workspaces that are configured with a `.clangd-contexts` file, the CLI supports an additional command `select-context` that activates a named context in all projects that have a context of that name.
+For example, executing the following command:
+
+```console
+clangd-context select-context Release_Atom
+```
+
+results in all of the context directories listed in the `.clangd-context` file having the build configuration "Release_Atom" applied to their `.clangd` file, if they have a "Release_Atom" configuration.
+In the example project, following up with a `get-context` command would look something like this:
+
+```console
+$ clangd-context get-context lib
+{
+  name: 'Release_Atom',
+  compilationDatabase: '/home/me/git/theia-cpp-extensions/examples/clangd-workspace/lib/Release_Atom'
+}
+```
+
+Projects that do not have the named context are unchanged.
+If the context name is not known in any project in the workspace, then the CLI exits with an error.
+
+### Changing Compile Flags
+
+In addition to getting and setting the context, the CLI provides commands for setting the compile flags that are evaluated by the clangd server.
+This is done with the `set-flags` and `unset-flags` commands.
+As usual the main argument is the location of the `.clangd` configuration file or its parent directory.
+
+#### Setting Compile Flags to be Added or Removed
+
+The `set-flags` command updates the `.clangd` configuration to specify flags that the language server should add to or remove from its invocations of the compiler.
+
+With the `--add` (`-a`) option the set of flags that should be added to those already specified in the compilation database can be configured.
+The `--remove` (`-r`) option sets which flags in the compilation database should be suppressed in the language server's invocation of the compiler.
+
+A command that tells the clangd server to suppress the `-fstack-usage` flag looks like this:
+
+```console
+clangd-context set-flags -r fstack-usage app
+```
+
+> **Note** that the command line here names the `-fstack-usage` compiler flag simply as "fstack-usage" without the initial "-". This is necessary because otherwise it would be interpreted as a command-line option for the `clangd-context` tool, itself. Multiple compiler flags can be added or removed at once by specifying them in a comma-separated list in the `-a` or `-r` option.
+
+The resulting `.clangd` file for the `Release_Atom` context in the `app` project looks like this:
+
+```yaml
+CompileFlags:
+    CompilationDatabase: >-
+        /home/me/git/theia-cpp-extensions/examples/clangd-workspace/app/Release_Atom
+    Remove:
+        - "-fstack-usage"
+```
+
+The project name argument ("`app`" in the example above) is optional if the workspace is configured with a `.clangd-contexts` file.
+In this case, omitting the project name applies the compile flags change to all projects listed in the `.clangd-contexts` file.
+
+#### Forgetting Configuration of Compile Flags
+
+To reverse previous additions or removals of compiler flags in the `.clangd` configuration, use the `unset-flags` command.
+This deletes occurrences of flags so that they are no longer added or removed from compiler command-lines by the language
+server, depending on the previous configuration.
+
+A command that tells the clangd server not to override the usage of the `-fstack-usage` flag in the compiler command looks like this:
+
+```console
+clangd-context unset-flags -f fstack-usage app
+```
+
+> **Note** that, as for the `set-flags` command, at least the first flag of the comma-separated list in the `-f` option must omit the initial "-".
+
+The resulting `.clangd` file for the `Release_Atom` context in the `app` project then is reverted to this:
+
+```yaml
+CompileFlags:
+    CompilationDatabase: >-
+        /home/me/git/theia-cpp-extensions/examples/clangd-workspace/app/Release_Atom
+```
+
+The project name argument ("`app`" in the example above) is optional if the workspace is configured with a `.clangd-contexts` file.
+In this case, omitting the project name applies the compile flags change to all projects listed in the `.clangd-contexts` file.
+
+## Example Workspaces
+
+-   [`examples/clangd-workspace`](../clangd-workspace/README.md)
+    -   provides a small example project with two interrelated projects in which to test drive the CLI tool
+
+## License
+
+-   [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+-   [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+
+"Theia" is a trademark of the Eclipse Foundation.  
+<https://www.eclipse.org/theia>

--- a/examples/clangd-contexts-cli/compile.tsconfig.json
+++ b/examples/clangd-contexts-cli/compile.tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../../packages/clangd-contexts/compile.tsconfig.json"
+    }
+  ]
+}

--- a/examples/clangd-contexts-cli/overrides.eslintrc.json
+++ b/examples/clangd-contexts-cli/overrides.eslintrc.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json.schemastore.org/eslintrc",
+  "overrides": [
+    {
+      "files": [
+        "**/app.ts"
+      ],
+      "rules": {
+        "@typescript-eslint/tslint/config": [
+          "error",
+          {
+            "rules": {
+              "file-header": false,
+              "jsdoc-format": [
+                true,
+                "check-multiline-start"
+              ],
+              "one-line": [
+                true,
+                "check-open-brace",
+                "check-catch",
+                "check-else",
+                "check-whitespace"
+              ],
+              "typedef": [
+                true,
+                "call-signature",
+                "property-declaration"
+              ],
+              "whitespace": [
+                true,
+                "check-branch",
+                "check-decl",
+                "check-operator",
+                "check-separator",
+                "check-type"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/clangd-contexts-cli/package.json
+++ b/examples/clangd-contexts-cli/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@theia/clangd-contexts-cli",
+  "displayName": "Theia Clangd Contexts CLI",
+  "description": "Theia - Command-line tool for management of configuration contexts in clangd.",
+  "version": "1.0.0",
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+  "dependencies": {
+    "@theia/clangd-contexts": "1.0.0",
+    "commander": "^8.1.0",
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.2",
+    "@types/node": "~12"
+  },
+  "scripts": {
+    "clean": "rimraf lib *.tsbuildinfo && rimraf .eslintcache && rimraf .nyc_output coverage",
+    "lint": "if-env SKIP_LINT=true && echo 'skip lint check' || eslint --cache=true --no-error-on-unmatched-pattern=true \"{src,test}/**/*.{ts,tsx}\"",
+    "build": "tsc -b compile.tsconfig.json && chmod +x lib/app.js",
+    "cli": "node lib/app.js"
+  },
+  "files": [
+    "lib"
+  ],
+  "main": "lib/index",
+  "types": "lib/index",
+  "bin": {
+    "clangd-context": "lib/app.js"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/examples/clangd-contexts-cli/src/app.ts
+++ b/examples/clangd-contexts-cli/src/app.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { Command } from 'commander';
+
+/*
+ * The entry point for the clangd-context CLI application.
+ */
+const program = new Command()
+    .name('clangd-context')
+    .showHelpAfterError(true)
+    .command('get-context', 'get the context in a project configuration', { executableFile: 'get-context-cmd' })
+    .command('set-context', 'set or change the context in a project configuration', {
+        executableFile: 'set-context-cmd',
+    })
+    .command('list', 'list the projects in the clangd workspace', { executableFile: 'list-cmd' })
+    .command('list-contexts', 'list the contexts of the projects in the clangd workspace', {
+        executableFile: 'list-contexts-cmd',
+    })
+    .command('select-context', 'select a context to activate in every project in the workspace', {
+        executableFile: 'select-context-cmd',
+    })
+    .command('set-flags', 'set added/removed compile flags in a project', { executableFile: 'set-flags-cmd' })
+    .command('unset-flags', 'unset added/removed compile flags in a project', { executableFile: 'unset-flags-cmd' });
+
+program.parse(process.argv);

--- a/examples/clangd-contexts-cli/src/get-context-cmd.ts
+++ b/examples/clangd-contexts-cli/src/get-context-cmd.ts
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { Command } from 'commander';
+import { getContext, ClangdContext } from '@theia/clangd-contexts';
+import { validateAndResolveConfig } from './validation';
+
+/** Placeholder for the empty/undefined clangd context. */
+export const NO_CONTEXT: ClangdContext = {
+    name: 'NO_CONTEXT',
+    compilationDatabase: '',
+};
+
+const program = new Command()
+    .name('get-context')
+    .showHelpAfterError(true)
+    .description('Get the clangd context for a given project directory or .clangd file')
+    .argument(
+        '<project>',
+        'The project directory (or .clangd file) for which the clangd context should be retrieved',
+        value => validateAndResolveConfig(value, true)
+    );
+
+program.parse();
+const directory = program.processedArgs[0];
+
+console.log(getContext(directory) ?? NO_CONTEXT);

--- a/examples/clangd-contexts-cli/src/list-cmd.ts
+++ b/examples/clangd-contexts-cli/src/list-cmd.ts
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { Command } from 'commander';
+import { listProjects, getClangdContextsConfig } from '@theia/clangd-contexts';
+import { requireContextsConfig } from './validation';
+
+const cwd = process.cwd();
+const contextsConfig = getClangdContextsConfig(cwd);
+
+const program = new Command()
+    .name('list')
+    .showHelpAfterError(true)
+    .description('List the projects in the current clangd workspace');
+
+program.parse();
+
+listProjects(requireContextsConfig(contextsConfig), cwd);

--- a/examples/clangd-contexts-cli/src/list-contexts-cmd.ts
+++ b/examples/clangd-contexts-cli/src/list-contexts-cmd.ts
@@ -1,0 +1,30 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { Command } from 'commander';
+import { listContexts, getClangdContextsConfig } from '@theia/clangd-contexts';
+import { requireContextsConfig } from './validation';
+
+const contextsConfig = getClangdContextsConfig(process.cwd());
+
+const program = new Command()
+    .name('list-contexts')
+    .showHelpAfterError(true)
+    .description('List the unique context names found in the current clangd workspace');
+
+program.parse();
+
+listContexts(requireContextsConfig(contextsConfig));

--- a/examples/clangd-contexts-cli/src/select-context-cmd.ts
+++ b/examples/clangd-contexts-cli/src/select-context-cmd.ts
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { Command } from 'commander';
+import { selectContext, getClangdContextsConfig } from '@theia/clangd-contexts';
+import { validateContextName, requireContextsConfig } from './validation';
+
+const contextsConfig = getClangdContextsConfig(process.cwd());
+
+const program = new Command()
+    .name('select-context')
+    .showHelpAfterError(true)
+    .description('Select a context to activate in every project in the clangd workspace')
+    .argument('<context>', 'The name of the context to select', value => validateContextName(value, contextsConfig));
+
+program.parse();
+const contextName = program.processedArgs[0];
+
+selectContext(requireContextsConfig(contextsConfig), contextName);

--- a/examples/clangd-contexts-cli/src/set-context-cmd.ts
+++ b/examples/clangd-contexts-cli/src/set-context-cmd.ts
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { Command } from 'commander';
+import { setContext } from '@theia/clangd-contexts';
+import { validateAndResolveContextDirectory, validateAndResolveConfig } from './validation';
+
+const program = new Command()
+    .name('set-context')
+    .showHelpAfterError(true)
+    .description('Set or change the clangd context for a given project')
+    .argument(
+        '<project>',
+        'The project directory (or .clangd file) for which the clangd context should be set',
+        value => validateAndResolveConfig(value, true)
+    )
+    .requiredOption(
+        '-c, --compile-commands <ccPath>',
+        'The path to the compilation database or its parent directory',
+        validateAndResolveContextDirectory
+    );
+
+program.parse();
+const options = program.opts();
+const directory = program.processedArgs[0];
+
+setContext(directory, options.compileCommands);

--- a/examples/clangd-contexts-cli/src/set-flags-cmd.ts
+++ b/examples/clangd-contexts-cli/src/set-flags-cmd.ts
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { Command } from 'commander';
+import { forAllProjects, setCompileFlags } from '@theia/clangd-contexts';
+import { validateAndResolveConfig, collectFlags, requireContextsConfig } from './validation';
+
+const program = new Command()
+    .name('set-flags')
+    .showHelpAfterError(true)
+    .description('Set compile flags to be added or removed in a clangd configuration')
+    .argument('[configPath]', 'Path to the clangd configuration file or its parent directory', validateAndResolveConfig)
+    .option(
+        '-a, --add <flags>',
+        'Comma-separated list of compile flags that should be added to source file parsing. The leading "-" of the first flag must be omitted',
+        collectFlags
+    )
+    .option(
+        '-r, --remove <flags>',
+        'Comma-separated list of compile flags that should be removed from source file parsing. The leading "-" of the first flag must be omitted',
+        collectFlags
+    );
+
+program.parse();
+const options = program.opts();
+const configPath = program.processedArgs[0];
+
+if (configPath) {
+    setCompileFlags(configPath, options.add, options.remove);
+} else {
+    forAllProjects(requireContextsConfig(), proj => setCompileFlags(proj, options.add, options.remove));
+}

--- a/examples/clangd-contexts-cli/src/unset-flags-cmd.ts
+++ b/examples/clangd-contexts-cli/src/unset-flags-cmd.ts
@@ -1,0 +1,40 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { Command } from 'commander';
+import { forAllProjects, unsetCompileFlags } from '@theia/clangd-contexts';
+import { validateAndResolveConfig, collectFlags, requireContextsConfig } from './validation';
+
+const program = new Command()
+    .name('unset-flags')
+    .showHelpAfterError(true)
+    .description('Forget compile flags that previously were set as added or removed in a clangd configuration')
+    .argument('[configPath]', 'Path to the clangd configuration file or its parent directory', validateAndResolveConfig)
+    .option(
+        '-f, --flags <flags>',
+        'Comma-separated list of added/removed compile flags to be deleted from the clangd configuration. The leading "-" of the first flag must be omitted',
+        collectFlags
+    );
+
+program.parse();
+const options = program.opts();
+const configPath = program.processedArgs[0];
+
+if (configPath) {
+    unsetCompileFlags(configPath, options.flags);
+} else {
+    forAllProjects(requireContextsConfig(), proj => unsetCompileFlags(proj, options.flags));
+}

--- a/examples/clangd-contexts-cli/src/validation.ts
+++ b/examples/clangd-contexts-cli/src/validation.ts
@@ -1,0 +1,177 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { exit } from 'process';
+import { COMPILE_COMMANDS_FILE, ClangdContextsConfig, CONFIG_FILE_NAME, getClangdContextsConfig, isDirectory, isFile } from '@theia/clangd-contexts';
+
+/**
+ * Validate the given file string and resolve it to a normalized absolute path.
+ * Prints an error and exits the application if the given
+ * string is not a valid, existing file.
+ *
+ * @param value a path string to validate
+ * @returns the validated and resolved file
+ */
+export function validateAndResolveFile(value: string): string {
+    if (!isFile(value)) {
+        console.error(`Invalid argument: '${value}' is not a valid, existing file path.`);
+        exit(1);
+    }
+
+    return path.resolve(value);
+}
+
+/**
+ * Validate the given directory string and resolve it to a normalized absolute path.
+ * Prints an error and exits the application if the given
+ * string is not a valid, existing directory.
+ *
+ * @param value a path string to validate
+ * @returns the validated and resolved directory
+ */
+export function validateAndResolveDirectory(value: string): string {
+    if (!isDirectory(value)) {
+        console.error(`Invalid argument: '${value}' is not a valid, existing directory path.`);
+        exit(1);
+    }
+
+    return path.resolve(value);
+}
+
+/**
+ * Validate and resolve the given `.clangd` path string.
+ * Prints an error and exits the application if the given string is not a
+ * valid `.clangd` file or a valid, existing directory containing a `.clangd` file.
+ *
+ * @param value a path string to validate
+ * @param [lax] whether to accept a directory that does not contain a `.clang` file. By default,
+ *   the `.clangd` file is required (`lax = false`)
+ * @returns the validated and resolved directory containing the `.clangd` configuration file
+ *
+ * @see validateAndResolveFile
+ * @see validateAndResolveDirectory
+ */
+export function validateAndResolveConfig(value: string, lax = false): string {
+    if (path.basename(value) === CONFIG_FILE_NAME) {
+        const configFile = validateAndResolveFile(value);
+        return path.dirname(configFile);
+    }
+
+    let result = validateAndResolveDirectory(value);
+    if (fs.readdirSync(value).includes(CONFIG_FILE_NAME)) {
+        value = path.join(value, CONFIG_FILE_NAME);
+        result = validateAndResolveFile(value);
+    } else if (!lax) {
+        console.error(`Invalid argument: the directory '${value}' does not contain a ${CONFIG_FILE_NAME} file.`);
+        exit(1);
+    }
+    return result;
+}
+
+/**
+ * Validate and resolve the given context path string.
+ * Prints an error and exits the application if the given
+ * string is not a valid `compile_commands.json` file or a valid, existing directory containing
+ * a `compile_commands.json` file.
+ *
+ * @param value a path string to validate as a compilation database directory
+ * @returns the validated and resolved compilation database directory
+ *
+ * @see validateAndResolveFile
+ * @see validateAndResolveDirectory
+ */
+export function validateAndResolveContextDirectory(value: string): string {
+    if (path.basename(value) === COMPILE_COMMANDS_FILE) {
+        const configFile = validateAndResolveFile(value);
+        return path.dirname(configFile);
+    }
+
+    const result = validateAndResolveDirectory(value);
+    if (!fs.readdirSync(value).includes(COMPILE_COMMANDS_FILE)) {
+        console.error(
+            `Invalid argument: the directory '${value}' is not a valid context directory.
+             It does not contain a ${COMPILE_COMMANDS_FILE} file.`
+        );
+        exit(1);
+    }
+    return result;
+}
+
+/**
+ * Validate the given context name string. Prints an error and exits the application if the given string is not the
+ * name of a known context directory in the projects configured in the  `.clangd-contexts` file.
+ *
+ * @param value a path string to validate as a clangd context name
+ * @param contextsConfig the current contexts configuration, if there is one
+ * @returns the validated clangd context name
+ */
+export function validateContextName(value: string, contextsConfig?: ClangdContextsConfig): string {
+    const configurations = requireContextsConfig(contextsConfig).getClangdContexts();
+
+    if (!configurations.includes(value)) {
+        console.error(`No such context "${value}" is defined.`);
+        exit(1);
+    }
+
+    return value;
+}
+
+/**
+ * Ensure that the `.clangd-contexts` file is loaded. If the `contextsConfig` is `undefined`, then
+ * it is sought and loaded. If that fall-back fails, then exit the CLI with an error code. Thus, this
+ * operation can only return normally.
+ *
+ * @param contextsConfig an optional already-loaded `.clangd-contexts` configuration
+ * @returns the `contextsConfig` if it was already loaded, otherwise a freshly loaded `.clangd-contexts` configuration
+ */
+export function requireContextsConfig(contextsConfig?: ClangdContextsConfig): ClangdContextsConfig {
+    const result = contextsConfig ?? getClangdContextsConfig(process.cwd());
+
+    if (!result) {
+        console.error('No .clangd-contexts file found. Configuration must be set explicitly in each project.');
+        exit(1);
+    }
+
+    return result;
+}
+
+/**
+ * Collect a list of `clang` flags that are the value of a command-line option into an aggregate
+ * of all such lists parsed from the same option. Additionally, any flags that are not preceded
+ * by a hyphen (dash) are prepended with a hyphen.
+ *
+ * @param value the comma-separated list of tokens to parse as an array of `clang` flags
+ * @param previousValue the array of tokens parsed so far for the flags (for the same command-line option)
+ * @param compileFlags flags in the `clang` command-line
+ * @returns the collected and dashified flags
+ */
+export function collectFlags(value: string, previousValue?: string[]): string[] {
+    let result = previousValue ?? [];
+    result = result.concat(ensureLeadingDash(value.split(/\s*,\s*/)));
+    return result;
+}
+
+/**
+ * Add the leading `-` to any flags that do not already have it.
+ *
+ * @param compileFlags flags in the `clang` command-line
+ * @returns the dashified flags
+ */
+function ensureLeadingDash(compileFlags: string[]): string[] {
+    return compileFlags.map(flag => (flag.startsWith('-') ? flag : `-${flag}`));
+}

--- a/examples/clangd-contexts-ext/.vscodeignore
+++ b/examples/clangd-contexts-ext/.vscodeignore
@@ -1,0 +1,13 @@
+.vscode/**
+.vscode-test/**
+out/test/**
+
+src/**
+.gitignore
+.yarnrc
+**/compile.tsconfig.*
+**/tsconfig.json
+**/.eslintrc.json
+**/.eslintcache
+**/*.map
+**/*.ts

--- a/examples/clangd-contexts-ext/README.md
+++ b/examples/clangd-contexts-ext/README.md
@@ -1,0 +1,69 @@
+# theia-clangd-contexts-ext
+
+## Overview
+
+An example application of the _Clangd Contexts API_, in the form of a simple VS Code extension.
+The extension maps the _context_ concept of the API onto the notion of _build configuration_ (or _build target_) familiar from IDEs such as Apple Xcode or Eclipse CDT.
+
+## Features
+
+-   quickly and easily apply clangd contexts described by `compile_commands.json` files to projects in the workspace
+-   configure clangd's invocation of `clang` to suppress GCC flags such as `-fstack-usage` that are not recognized by clang
+
+## How to Run the Example VS Code Extension
+
+The most convenient way to run the extension with debugger support for stepping through the code is via the _Launch Clangd Contexts Example Extension_ launch configuration in VS Code.
+The run-time workbench then provides
+
+-   a build configuration selection widget in the status line
+-   a context menu action on folders in the _Explorer_ view to configure GCC flags to suppress in the clangd configuration
+
+The launch configuration opens a VS Code run-time workbench on the example workspace (see below).
+
+Alternatively, the extension is built and packaged also in the browser and Electron example applications.
+These example apps can be launched on the _clangd contexts_ example workspace as follows:
+
+```console
+# for the clangd example workspace opened in the browser
+$ yarn start:browser:clangd
+# for the clangd example workspace opened in the Electron deployment
+$ yarn start:electron:clangd
+```
+
+## Using the Example VS Code Extension
+
+The [example workspace](../clangd-workspace/README.md) contains two projects, `app/` and `lib/`.
+If we have a look at the `app/main.c` file we can see a compilation error because the reference to a name defined in the `lib/` project cannot be resolved.
+To fix this a build configuration needs to be set.
+
+> **Note** that until the example workspace has first been built [according to these instructions](../clangd-workspace/README.md#how-to-build-the-workspace), VS Code will not be able to show any build configurations to choose because the context directories containing the requisite makefiles and compilation databases do not yet exist.
+
+This can be done via the command palette using the `Clangd: Change build configuration` command.
+Alternatively, the build configuration can be configured by clicking on the build configuration item on the status bar.
+
+> **Note** that the `Clangd: Change build configuration` command also restarts the clangd language server to apply the configuration changes.
+> Some errors regarding rejected promises may be thrown by restarting the language server.
+> However, they are harmless and can safely be ignored.
+
+Clangd uses a dedicated cache per build configuration index, which means that switching between configurations does not require a full re-indexing.
+
+The `Debug_x86-64` configuration uses a GCC-specific compile flag which is not recognized by clangd.
+To avoid errors related to unsupported GCC compile flags the `Clangd: Suppress unsupported GCC flags"` command can be used.
+It is also possible to suppress GCC flags only in a specific subdirectory.
+Simply select the directory in the file explorer, open the context menu and select `Clangd: Suppress unsupported GCC flags"`.
+The `theia-clangd-contexts-ext` extension then recursively collects all `.clangd` configuration files that are located within the workspace or within the selected directory and adds a configuration option that tells the clangd server to suppress the unsupported compilation flags.
+
+## Example Workspaces
+
+-   [`examples/clangd-workspace`](../clangd-workspace/README.md)
+    -   provides a small example workspace with two interrelated projects in which to test-drive the _Clangd Contexts_ API via the extension
+
+## License
+
+-   [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+-   [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+
+"Theia" is a trademark of the Eclipse Foundation.  
+<https://www.eclipse.org/theia>

--- a/examples/clangd-contexts-ext/compile.tsconfig.json
+++ b/examples/clangd-contexts-ext/compile.tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../../packages/clangd-contexts/compile.tsconfig.json"
+    }
+  ]
+}

--- a/examples/clangd-contexts-ext/package.json
+++ b/examples/clangd-contexts-ext/package.json
@@ -1,0 +1,73 @@
+{
+  "private": true,
+  "name": "theia-clangd-contexts-ext",
+  "displayName": "Theia Clangd Contexts Extension",
+  "description": "Theia - Extension to provide clangd context support.",
+  "version": "1.0.0",
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+  "publisher": "theia",
+  "repository": "https://github.com/eclipse-theia/theia-cpp-extensions",
+  "engines": {
+    "vscode": "^1.59.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "keywords": [
+    "multi-root ready",
+    "clangd"
+  ],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "main": "./lib/extension.js",
+  "scripts": {
+    "clean": "rimraf lib *.tsbuildinfo && rimraf .eslintcache && rimraf .nyc_output coverage",
+    "package": "vsce package --no-yarn && copyfiles theia-clangd-contexts-ext-1.0.0.vsix ../../plugins",
+    "lint": "if-env SKIP_LINT=true && echo 'skip lint check' || eslint --cache=true --no-error-on-unmatched-pattern=true \"{src,test}/**/*.{ts,tsx}\"",
+    "build": "tsc -b compile.tsconfig.json",
+    "watch": "tsc -p compile.tsconfig.json -w"
+  },
+  "dependencies": {
+    "@theia/clangd-contexts": "1.0.0"
+  },
+  "contributes": {
+    "commands": [
+      {
+        "command": "theia-clangd-contexts.change.buildConfig",
+        "title": "Clangd: Change build configuration"
+      },
+      {
+        "command": "theia-clangd-contexts.ignore.gccFlags",
+        "title": "Clangd: Suppress unsupported GCC flags"
+      }
+    ],
+    "menus": {
+      "explorer/context": [
+        {
+          "when": "explorerResourceIsFolder",
+          "command": "theia-clangd-contexts.ignore.gccFlags",
+          "group": "file"
+        }
+      ]
+    }
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^9.0.13",
+    "@types/mocha": "^8.2.2",
+    "@types/node": "14.x",
+    "@types/vscode": "^1.59.0",
+    "@typescript-eslint/eslint-plugin": "^4.26.0",
+    "@typescript-eslint/parser": "^4.26.0",
+    "copyfiles": "^2.4.1",
+    "eslint": "^7.27.0",
+    "mocha": "^8.4.0",
+    "vsce": "^1.100.1",
+    "vscode-test": "^1.5.2"
+  },
+  "workspaces": {
+    "nohoist": [
+      "**/@theia/clangd-contexts"
+    ]
+  }
+}

--- a/examples/clangd-contexts-ext/src/build-configuration.ts
+++ b/examples/clangd-contexts-ext/src/build-configuration.ts
@@ -1,0 +1,126 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { getContext, setContext, ClangdContext } from '@theia/clangd-contexts';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { findMatchingFiles, restartClangdLanguageServer } from './util';
+
+/** Placeholder for the empty/undefined clangd context. */
+const NO_CONTEXT: ClangdContext = {
+    name: 'NO_CONTEXT',
+    compilationDatabase: '',
+};
+
+const projectDirs: string[] = [];
+export const COMPILATION_DATABASE_FILE = 'compile_commands.json';
+export const CLANGD_CONFIG_FILE = '.clangd';
+export const buildConfigurations: Map<string, BuildConfiguration[]> = new Map();
+
+export interface BuildConfiguration {
+    rootDir: string;
+    contextDirectory: string;
+}
+
+export async function loadBuildConfiguration(): Promise<void> {
+    if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
+        updateBuildConfigStatus();
+        return;
+    }
+    buildConfigurations.clear();
+    const uniqueRoots = collectUniqueRootDirs(vscode.workspace.workspaceFolders);
+    const compilationDbs = findMatchingFiles(uniqueRoots, file => file.endsWith(COMPILATION_DATABASE_FILE));
+    compilationDbs.forEach(compilationDatabase => {
+        const contextDirectory = path.dirname(compilationDatabase);
+        const configName = path.basename(contextDirectory);
+        const rootDir = path.dirname(contextDirectory);
+        if (!projectDirs.includes(rootDir)) {
+            projectDirs.push(rootDir);
+        }
+        const configs = buildConfigurations.get(configName) ?? [];
+        configs.push({ rootDir, contextDirectory });
+        buildConfigurations.set(configName, configs);
+    });
+
+    const configDirs = projectDirs.map(dir => getContext(dir) ?? NO_CONTEXT);
+    if (configDirs.length > 0) {
+        const buildConfigName = configDirs[0].name;
+        if (configDirs.every(context => context.name === buildConfigName)) {
+            updateBuildConfigStatus(buildConfigName);
+            return;
+        }
+    }
+    updateBuildConfigStatus();
+}
+
+let contextStatusItem: vscode.StatusBarItem;
+
+export function createBuildConfigurationStatusItem(): vscode.StatusBarItem {
+    contextStatusItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+    contextStatusItem.command = CHANGE_BUILD_CONFIGURATION_COMMAND;
+    contextStatusItem.show();
+    updateBuildConfigStatus();
+    return contextStatusItem;
+}
+
+export function updateBuildConfigStatus(buildConfiguration?: string): void {
+    contextStatusItem.text = `Build configuration: ${buildConfiguration ?? 'NONE'}`;
+}
+
+export const CHANGE_BUILD_CONFIGURATION_COMMAND = 'theia-clangd-contexts.change.buildConfig';
+
+export async function changeBuildConfigurationCommandHandler(configs: Map<string, BuildConfiguration[]>): Promise<void> {
+    if (configs.size === 0) {
+        vscode.window.showQuickPick([], {
+            title: 'Select new build configuration',
+            placeHolder: 'Could not find any build configurations for this workspace.',
+        });
+        return;
+    }
+
+    const newConfigName = await vscode.window.showQuickPick(Array.from(configs.keys()), {
+        title: 'Select new build configuration',
+        placeHolder: 'Name of the build configuration',
+    });
+
+    if (newConfigName) {
+        const result = configs.get(newConfigName) ?? [];
+        result.forEach(buildConfig => setContext(buildConfig.rootDir, buildConfig.contextDirectory));
+        await restartClangdLanguageServer();
+        vscode.window.showInformationMessage(`Build configuration has been changed to: ${newConfigName}`);
+        updateBuildConfigStatus(newConfigName);
+    }
+}
+
+/**
+ * Collect the unique root directories amongst a list of workspace folders.
+ * The unique root directories exclude any that are subdirectories of other workspace
+ * roots (VS Code allows directories within some workspace root to be added as additional roots).
+ *
+ * @param workspaces the workspace root folders
+ * @returns the unique root folders
+ */
+function collectUniqueRootDirs(workspaces: readonly vscode.WorkspaceFolder[]): string[] {
+    // These directory paths all end with a path separator so that prefix testing matches
+    // only whole path segments
+    const roots = workspaces.map(ws => normalizeDir(ws.uri.path));
+    return roots.filter(root => !roots.some(other => root !== other && other.startsWith(root)));
+}
+
+function normalizeDir(dir: string): string {
+    const result = path.normalize(dir);
+    return result.endsWith(path.sep) ? result : result + path.sep;
+}

--- a/examples/clangd-contexts-ext/src/extension.ts
+++ b/examples/clangd-contexts-ext/src/extension.ts
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import * as vscode from 'vscode';
+import {
+    buildConfigurations,
+    changeBuildConfigurationCommandHandler,
+    CHANGE_BUILD_CONFIGURATION_COMMAND,
+    CLANGD_CONFIG_FILE,
+    COMPILATION_DATABASE_FILE,
+    createBuildConfigurationStatusItem,
+    loadBuildConfiguration,
+    updateBuildConfigStatus,
+} from './build-configuration';
+import { ignoreGCCFlagsCommandHandler, IGNORE_GCC_FLAGS_COMMAND } from './ignore-gcc-flags-command';
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+    context.subscriptions.push(
+        vscode.commands.registerCommand(CHANGE_BUILD_CONFIGURATION_COMMAND, () =>
+            changeBuildConfigurationCommandHandler(buildConfigurations)
+        )
+    );
+    context.subscriptions.push(
+        vscode.commands.registerCommand(IGNORE_GCC_FLAGS_COMMAND, (...args: unknown[]) => ignoreGCCFlagsCommandHandler(args))
+    );
+
+    context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(() => loadBuildConfiguration()));
+
+    const cdbWatcher = vscode.workspace.createFileSystemWatcher(`**/${COMPILATION_DATABASE_FILE}`, false, true, false);
+    context.subscriptions.push(cdbWatcher);
+    context.subscriptions.push(cdbWatcher.onDidCreate(handleFileChange));
+    context.subscriptions.push(cdbWatcher.onDidDelete(clearBuildConfigStatus));
+
+    const configWatcher = vscode.workspace.createFileSystemWatcher(`**/${CLANGD_CONFIG_FILE}`, false, false, false);
+    context.subscriptions.push(configWatcher);
+    context.subscriptions.push(configWatcher.onDidCreate(handleFileChange));
+    context.subscriptions.push(configWatcher.onDidChange(handleFileChange));
+    context.subscriptions.push(configWatcher.onDidDelete(clearBuildConfigStatus));
+
+    // Unlike the CLI example, this example does not use nor recognize `.clangd-contexts` files
+
+    createBuildConfigurationStatusItem();
+    loadBuildConfiguration();
+}
+
+function handleFileChange(uri: vscode.Uri): void {
+    if (uri.path.endsWith(COMPILATION_DATABASE_FILE) || uri.path.endsWith(CLANGD_CONFIG_FILE)) {
+        loadBuildConfiguration();
+    }
+}
+
+function clearBuildConfigStatus(uri: vscode.Uri): void {
+    updateBuildConfigStatus();
+}
+
+// this method is called when your extension is deactivated
+export function deactivate(): void { }

--- a/examples/clangd-contexts-ext/src/ignore-gcc-flags-command.ts
+++ b/examples/clangd-contexts-ext/src/ignore-gcc-flags-command.ts
@@ -1,0 +1,50 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { CONFIG_FILE_NAME, setCompileFlags } from '@theia/clangd-contexts';
+import * as vscode from 'vscode';
+import { findMatchingFiles, restartClangdLanguageServer } from './util';
+export const IGNORE_GCC_FLAGS_COMMAND = 'theia-clangd-contexts.ignore.gccFlags';
+export const GCC_FLAGS = ['-fstack-usage'];
+
+export async function ignoreGCCFlagsCommandHandler(args: unknown[]): Promise<void> {
+    // As the VS Code workspace may have multiple roots, we support any number of URI args
+    let paths = getPaths(args)?.map(uri => uri.fsPath);
+    if (!paths && vscode.workspace.workspaceFolders) {
+        paths = vscode.workspace.workspaceFolders.map(folder => folder.uri).filter(isFileUri).map(uri => uri.fsPath);
+    }
+
+    if (!paths || paths?.length === 0) {
+        return;
+    }
+
+    paths.map(path => findMatchingFiles(path, file => file.endsWith(CONFIG_FILE_NAME)))
+        .reduce((flattened, array) => flattened.concat(array), [])
+        .forEach(configFile => setCompileFlags(configFile, undefined, GCC_FLAGS));
+
+    await restartClangdLanguageServer();
+}
+
+function getPaths(args: unknown[]): vscode.Uri[] | undefined {
+    if (args.length > 0 && args.some(isFileUri)) {
+        return args.filter(isFileUri);
+    }
+    return undefined;
+}
+
+function isFileUri(object: unknown): object is vscode.Uri {
+    return object instanceof vscode.Uri && object.scheme === 'file';
+}

--- a/examples/clangd-contexts-ext/src/util.ts
+++ b/examples/clangd-contexts-ext/src/util.ts
@@ -1,0 +1,72 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { asArray } from '@theia/clangd-contexts/lib/util/maybe-array';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+/**
+ * Returns all files that match the given predicate, starting from a given start path. If the start path
+ * is a file this function will just check if the file matches the predicate. If the start path is a directory
+ * the function looks recursively for all matching files within the directory.
+ * @param startPath The start path(s)
+ * @param predicate The predicate that needs to be matched
+ * @returns All matching files as array.
+ */
+export function findMatchingFiles(startPath: string | string[], predicate: (file: string) => boolean): string[] {
+    let startPaths = asArray(startPath);
+    if (process.platform === 'win32') {
+        startPaths = startPaths.map(p => p.replace(/^\/+/, ''));
+    }
+
+    const results: string[] = [];
+    startPaths.forEach(p => collectMatchingFiles(p, predicate, results));
+    return results;
+}
+
+function collectMatchingFiles(startPath: string, predicate: (file: string) => boolean, results: string[]): void {
+    const fileStat = fs.statSync(startPath);
+    if (fileStat.isFile() && predicate(startPath)) {
+        results.push(startPath);
+        return;
+    }
+
+    const filenames = fs.readdirSync(startPath).map(file => path.join(startPath, file));
+    filenames.forEach(filename => {
+        const stat = fs.lstatSync(filename);
+        if (stat.isDirectory()) {
+            collectMatchingFiles(filename, predicate, results);
+        } else if (stat.isFile() && predicate(filename)) {
+            results.push(filename);
+        }
+    });
+}
+
+/**
+ * Helper function to restart the clangd language server.
+ * @returns A promise that resolves once the server has been successfully restarted.
+ */
+export async function restartClangdLanguageServer(): Promise<void> {
+    try {
+        await vscode.commands.executeCommand('clangd.restart');
+    } catch (error) {
+        /*
+         * Catch errors that might occur during stopping and starting the clangd language server
+         * and do not handle them, as they are expected.
+         */
+    }
+}

--- a/examples/clangd-workspace/.clangd-contexts
+++ b/examples/clangd-workspace/.clangd-contexts
@@ -1,0 +1,13 @@
+{
+    "workspaceName": "Theia Clangd Contexts Example",
+    "projects": [
+        {
+            "path": "app",
+            "contextDirs": "flat"
+        },
+        {
+            "path": "lib",
+            "contextDirs": "flat"
+        }
+    ]
+}

--- a/examples/clangd-workspace/.gitignore
+++ b/examples/clangd-workspace/.gitignore
@@ -1,0 +1,4 @@
+!lib/
+**/Debug_x86-64
+**/Release_Atom
+**/.clangd

--- a/examples/clangd-workspace/README.md
+++ b/examples/clangd-workspace/README.md
@@ -1,0 +1,76 @@
+# Example Workspace with Clangd Contexts
+
+This is a simple multi-project workspace that has two different _clangd contexts_ that should be properly handled by code completion suggestions and warnings in the code editor.
+
+## How to Open the Workspace
+
+The monorepo provides two scripts that open the example workspace in either the browser or the Electron deployment of Theia:
+
+```console
+# to build the example apps
+$ yarn
+# for the browser example
+$ yarn start:browser:clangd
+# for the Electron example
+$ yarn start:electron:clangd
+```
+
+## How to Build the Workspace
+
+Make sure that you have `gcc` from the GNU toolchain and `cmake` on the `PATH`.
+Then build the workspace using
+
+```console
+./build.sh
+```
+
+It will build the `CMakeLists.txt` in two flavors, for two different architectures, each with its own `compile_commands.json`:
+
+```text
+  app/
+    Debug_x86-64/
+    Release_Atom/
+  lib/
+    Debug_x86-64/
+    Release_Atom/
+```
+
+This is interesting because the built-in defined symbols differ.
+In `main.c` there are different warnings depending on the built-in defined symbols and the definition of the `TestStruct_t` is different depending on the target architecture.
+
+Line 22 will generate a warning in the `Atom` configurations, but not in the others because in those, the `__atom__` macro is not defined (not being built specifically for that CPU).
+
+## Context-sensitive Variation Points
+
+### Context
+
+The example workspace comprises two projects (`lib/` and `app/`) that each have potentially four different contexts on a 2x2 matrix of debug or release mode for generic x86-64 or Intel Atom CPU architectures.
+These contexts collect their makefiles and `compile_commands.json` files in a flat directory structure within each project:
+
+```text
+  app/
+    Debug_x86-64/
+    Release_Atom/
+  lib/
+    Debug_x86-64/
+    Release_Atom/
+```
+
+### Header Files
+
+Setting the context to use in the project lets clangd resolve header files correctly:
+
+-   open header files show information based on built-in defined symbols and "generic project-wide" compilation flags used for every file in the project
+    -   e.g. `-march=x86-64` vs `-march=atom` compiler flags yield different `#ifdef __atom__` conditional compilation
+
+### GCC Flags Filtering
+
+The compilation commands in the `compile_commands.json` databases of some build configurations can include flags supported by GCC that the clang toolchain used by clangd does not understand.
+The clangd configuration can specify flags that should be suppressed in the invocation of the clang compiler:
+
+-   e.g. `-fstack-usage` is a GCC flag used when compiling that yields an error for `clangd` because it is not supported by the clang compiler
+-   remove/filter GCC-specific flags to be clang compatible to avoid false errors for things that don't really matter for indexing
+-   add clang-specific flags as necessary to support clangd's analysis of the code
+
+> **Note** that on Mac platform, the `gcc` compiler provided by Xcode is actually based on `clang`, and so building the project via `build.sh` will also show the unrecognized `-fstack-usage` flag errors.
+> These can be ignored for the purposes of the example.

--- a/examples/clangd-workspace/app/CMakeLists.txt
+++ b/examples/clangd-workspace/app/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.5)
+set(CMAKE_SYSTEM_PROCESSOR x86-64)
+set(CMAKE_C_COMPILER_ID GNU)
+set(CMAKE_CXX_COMPILER_ID GNU)
+set(CMAKE_C_COMPILER_FORCED TRUE)
+set(CMAKE_CXX_COMPILER_FORCED TRUE)
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+project(cmake1)
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+set(TARGET_FLAGS "-Wconversion ${EXT_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${TARGET_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TARGET_FLAGS}")
+
+set(source_files
+    file_1.c
+    file_2.c
+    file_3.c
+    main.c
+)
+
+include_directories(
+    ../lib
+)
+
+link_libraries(-L../../lib/${LIBNAME} -l${LIBNAME})
+add_executable(cmake1 ${source_files})

--- a/examples/clangd-workspace/app/file_1.c
+++ b/examples/clangd-workspace/app/file_1.c
@@ -1,0 +1,3 @@
+int function_1() {
+    return 1;
+}

--- a/examples/clangd-workspace/app/file_2.c
+++ b/examples/clangd-workspace/app/file_2.c
@@ -1,0 +1,3 @@
+int function_2() {
+    return 2;
+}

--- a/examples/clangd-workspace/app/file_3.c
+++ b/examples/clangd-workspace/app/file_3.c
@@ -1,0 +1,3 @@
+int function_3() {
+    return 3;
+}

--- a/examples/clangd-workspace/app/files.h
+++ b/examples/clangd-workspace/app/files.h
@@ -1,0 +1,8 @@
+int function_1();
+int function_2();
+int function_3();
+
+typedef struct {
+    char* name;
+    int flags;
+} UserProfile_t;

--- a/examples/clangd-workspace/app/main.c
+++ b/examples/clangd-workspace/app/main.c
@@ -1,0 +1,24 @@
+#include "files.h"
+#include <lib.h>
+
+#ifdef __atom__
+ #warning "Arch Intel Atom"
+ typedef struct {
+     int a;
+ } TestStruct_t;
+#else
+ #warning "Other arch"
+  typedef struct {
+     float a;
+ } TestStruct_t;
+#endif
+
+volatile float global_value = 1.234f;
+
+int main() {
+    int arr[4] = {1, 2, 3, 4};
+
+    TestStruct_t obj;
+    obj.a = global_value + ((float)sum(arr, 4));
+    return 0;
+}

--- a/examples/clangd-workspace/build.sh
+++ b/examples/clangd-workspace/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#################################################################################
+# Copyright (c) 2021 STMicroelectronics and others.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# This Source Code may also be made available under the following Secondary
+# Licenses when the conditions for such availability set forth in the Eclipse
+# Public License v. 2.0 are satisfied: GNU General Public License, version 2
+# with the GNU Classpath Exception which is available at
+# https://www.gnu.org/software/classpath/license.html.
+#
+# SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+#################################################################################
+
+# Make sure that you have a 'gcc' compiler and 'cmake' on the PATH.
+
+configs=(
+  "Debug_x86-64::-march=x86-64 -O0 -g -ffunction-sections -fdata-sections -DDEBUG_ENABLED -fstack-usage"
+  "Release_Atom::-march=atom -mfpmath=sse -mhard-float -Os -g0 -ffunction-sections -fdata-sections -DRELEASE_ENABLED"
+)
+
+function build {
+  local config=$1
+  local build_dir=$2
+  local config_argline=$3
+  rm -rf $build_dir
+  mkdir $build_dir
+
+  (
+    cd $build_dir
+    cmake .. -G "Unix Makefiles" -DEXT_FLAGS="${config_argline}" -DLIBNAME=$config
+    make -j8
+  )
+}
+
+for config_entry in "${configs[@]}"; do
+  config="${config_entry%%::*}"
+  config_argline="${config_entry##*::}"
+  echo "Building $config"
+
+  build "$config" "lib/$config" "$config_argline"
+  build "$config" "app/$config" "$config_argline"
+done

--- a/examples/clangd-workspace/lib/CMakeLists.txt
+++ b/examples/clangd-workspace/lib/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.5)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+set(CMAKE_C_COMPILER_ID GNU)
+set(CMAKE_CXX_COMPILER_ID GNU)
+set(CMAKE_C_COMPILER_FORCED TRUE)
+set(CMAKE_CXX_COMPILER_FORCED TRUE)
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+project(lib)
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+set(TARGET_FLAGS "-Wconversion ${EXT_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${TARGET_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TARGET_FLAGS}")
+
+set(source_files
+    lib.c
+)
+
+add_library(${LIBNAME} STATIC ${source_files})

--- a/examples/clangd-workspace/lib/lib.c
+++ b/examples/clangd-workspace/lib/lib.c
@@ -1,0 +1,9 @@
+#include "lib.h"
+
+int sum(int arr[], int len) {
+    int result = 0;
+    for (int i = 0 ; i < len; i++) {
+        result += arr[i];
+    }
+    return result + MAGIC_VALUE;
+}

--- a/examples/clangd-workspace/lib/lib.h
+++ b/examples/clangd-workspace/lib/lib.h
@@ -1,0 +1,10 @@
+
+#ifdef __atom__
+ #warning "Arch Intel Atom"
+ #define MAGIC_VALUE 2
+#else
+ #warning "Other arch"
+ #define MAGIC_VALUE 1
+#endif
+
+int sum(int arr[], int len);

--- a/package.json
+++ b/package.json
@@ -35,10 +35,11 @@
   "scripts": {
     "preinstall": "node-gyp install",
     "postinstall": "node scripts/post-install.js",
-    "prepare": "yarn prepare:references && yarn prepare:build && yarn prepare:hoisting && yarn download:plugins",
+    "prepare": "yarn prepare:references && yarn prepare:build && yarn prepare:hoisting && yarn download:plugins && yarn prepare:package",
     "prepare:references": "node scripts/compile-references.js",
     "prepare:build": "yarn build && lerna run lint && lerna run build \"@theia/example-*\" --stream --parallel",
     "prepare:hoisting": "theia check:hoisted -s",
+    "prepare:package": "lerna run package theia-clangd-contexts-ext --stream",
     "clean": "yarn lint:clean && node scripts/run-reverse-topo.js yarn clean",
     "build": "tsc -b configs/root-compilation.tsconfig.json",
     "watch": "tsc -b configs/root-compilation.tsconfig.json -w",
@@ -60,7 +61,9 @@
     "next:publish": "lerna publish --exact --canary=next --npm-tag=next --yes",
     "publish:check": "node scripts/check-publish.js",
     "start:browser": "yarn rebuild:browser && yarn --cwd examples/browser start",
+    "start:browser:clangd": "yarn start:browser --root-dir=../clangd-workspace",
     "start:electron": "yarn rebuild:electron && yarn --cwd examples/electron start",
+    "start:electron:clangd": "yarn start:electron --root-dir=../clangd-workspace",
     "download:plugins": "theia download:plugins"
   },
   "workspaces": [

--- a/packages/clangd-contexts/.eslintrc.js
+++ b/packages/clangd-contexts/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'compile.tsconfig.json'
+    }
+};

--- a/packages/clangd-contexts/README.md
+++ b/packages/clangd-contexts/README.md
@@ -1,0 +1,117 @@
+# @theia/clangd-contexts
+
+## Overview
+
+An API for management of [clangd](https://clangd.llvm.org) configuration files in C/C++ projects using _contexts_.
+A _context_ is the set of flags, parameters, other settings and source files that clangd uses as input.
+Currently, this library is limited to configuring the compilation database (`compile_commands.json` file) and compile flags in the `.clangd` file for a project.
+Contexts are identified via the names of the directories containing `compile_commands.json` files.
+In the future additional settings may be associated with a specific context, for example the handling of additional or removed compilation flags (currently these are managed on an _ad hoc_ basis).
+
+## Features
+
+-   API for management of [clangd](https://clangd.llvm.org) configuration files
+-   retrieve and set contexts in one or more `.clangd` files
+-   manage compile flags in `.clangd` files
+
+The API in the `clangd-config` and `clangd-context` modules manages the `CompileFlags` configuration of _clangd_ in the `.clangd` files in a C/C++ project.
+In particular,
+
+-   which `CompilationDatabase` to use, referencing a `compile_commands.json` file
+-   any compiler flags to `Remove` from or `Add` to those specified in the compilation database when invoking `clang`
+
+The API establishes two core concepts: a _project_ that is configured via a `.clangd` file and a _context_ that identifies a compilation database (a particular `compile_commands.json` file).
+A context's name is inferred from the name of the directory that contains the compilation database file.
+A workspace may have one or more projects each configured with a `.clangd` file for different subtrees.
+Each project has one or more contexts and in a multi-project workspace the projects' context names may overlap to any degree.
+The [example workspace](../../examples/clangd-workspace/README.md) shows a fairly small example of how this can be laid out:
+
+```plain
+workspace/                           // a multi-project workspace
+  +-- app/                           // a project
+  |   +-- Debug_x86-64/              // a "Debug mode for x86-64 architecture" context
+  |   |   +-- compile_commands.json  // the context's compilation database
+  |   |   +-- Makefile
+  |   |   +-- ...
+  |   +-- Release_Atom/              // a "Release mode for Atom architecture" context
+  |   |   +-- compile_commands.json
+  |   |   +-- ...
+  |   +-- .clangd                    // the clangd configuration for the "app" project
+  +-- lib/                           // another project
+      +-- Debug_x86-64/              // similar context as in the "app" project
+      |   +-- compile_commands.json
+      |   +-- ...
+      +-- Release_Atom/              // similar context as in the "app" project
+      |   +-- compile_commands.json
+      |   +-- ...
+      +-- .clangd                    // the clangd configuration for the "lib" project
+```
+
+The core API for the `.clangd` configuration file does not assume any particular directory structure: client applications specify contexts to set into the `.clangd` file either by path to the `compile_commands.json` file or the directory containing it.
+The inferred name of the context, which is useful primarily for presentation to the user in a UI or command-line tool, is the path name of the parent directory of the `compile_commands.json` file relative to the `.clangd` file for the project.
+So, in the example above, the context names in both projects are "Debug_x86-64" and "Release_Atom".
+
+Another API in the `clangd-contexts-config` module is provided to help clients discover existing projects and contexts of a workspace that is configured with an optional `.clangd-contexts` file that describes the layout of the workspace.
+A workspace may have one of these at the root or may have several `.clangd-contexts` files in different subtrees.
+A `.clangd-contexts` file enumerates the project directories in its scope and, for each, indicates whether context directories are organized in a flat list as in the example above or hierarchically as in the structure below:
+
+```plain
+workspace/                           // a multi-project workspace
+  +-- app/                           // a project directory
+  |   +-- Debug/                     // "Debug mode" contexts
+  |   |   +-- x86-64/                // the "Debug mode" context for x86-64 architecture
+  |   |   |   +-- compile_commands.json
+  |   |   |   +-- Makefile
+  |   |   |   +-- ...
+  |   |   +-- Atom/                  // the "Debug mode" context for Atom architecture
+  |   |   |   +-- compile_commands.json
+  |   |   |   +-- Makefile
+  |   |   |   +-- ...
+  |   |   +-- Makefile
+  |   |   +-- ...
+  |   +-- Release/                   // "Release mode" contexts
+  |   |   +-- x86-64/                // the "Release mode" context for x86-64 architecture
+  |   |   |   +-- compile_commands.json
+  |   |   |   +-- Makefile
+  |   |   |   +-- ...
+  |   |   +-- Atom/                  // the "Release mode" context for Atom architecture
+  |   |   |   +-- compile_commands.json
+  |   |   |   +-- Makefile
+  |   |   |   +-- ...
+  |   |   +-- Makefile
+  |   |   +-- ...
+  |   +-- .clangd                    // the clangd configuration for the "app" project
+  +-- lib/                           // another project directory
+  |   +-- Debug/                     // similar context as in the "app" project
+  |   |   +-- x86-64/
+  |   |   +-- Atom/
+  |   |   +-- ...
+  |   +-- Release/                   // similar context as in the "app" project
+  |   |   +-- x86-64/
+  |   |   +-- Atom/
+  |   |   +-- ...
+  |   +-- .clangd                    // the clangd configuration for the "lib" project
+  +-- .clangd-contexts               // configuration of project layout in the workspace
+```
+
+The API around the `.clangd-contexts` configuration file provides functions for querying what are the configured project directories and what are the
+distinct context names available across all of those projects.
+In this layout, the distinct context names are "Debug/x86-64", "Debug/Atom", "Release/x86-64", and "Release/Atom".
+
+Currently, the `.clangd-contexts` file is limited to describing the shape of projects in the clangd workspace.
+A future enhancement should expand the configuration in this file to include lists of added/removed compile flags on a per project basis and, optionally, per context as well, allowing the `setContext` and `selectContext` APIs to update the added/removed compile flags in the `.clangd` configuration automatically on context switch.
+
+## Example Workspaces
+
+-   [`examples/clangd-workspace`](../../examples/clangd-workspace/README.md)
+    -   provides a small example workspace with two interrelated projects in which to test drive the API via the [VS Code Extension example](../../examples/clangd-contexts-ext/README.md) and/or the [CLI Example](../../examples/clangd-contexts-cli/README.md)
+
+## License
+
+-   [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+-   [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+
+"Theia" is a trademark of the Eclipse Foundation.  
+<https://www.eclipse.org/theia>

--- a/packages/clangd-contexts/compile.tsconfig.json
+++ b/packages/clangd-contexts/compile.tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": []
+}

--- a/packages/clangd-contexts/package.json
+++ b/packages/clangd-contexts/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@theia/clangd-contexts",
+  "displayName": "Theia Clangd Contexts",
+  "description": "Theia - Support for multiple configuration contexts in clangd.",
+  "version": "1.0.0",
+  "license": "EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "cpp",
+    "clangd"
+  ],
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/chai-string": "^1.4.2",
+    "@types/js-yaml": "^4.0.2",
+    "@types/node": "~12",
+    "chai-string": "^1.5.0"
+  },
+  "scripts": {
+    "clean": "rimraf lib *.tsbuildinfo && rimraf .eslintcache && rimraf .nyc_output coverage",
+    "lint": "if-env SKIP_LINT=true && echo 'skip lint check' || eslint --cache=true --no-error-on-unmatched-pattern=true \"{src,test}/**/*.{ts,tsx}\"",
+    "build": "tsc -b compile.tsconfig.json",
+    "test": "mocha --config ../../configs/mocharc.json \"./lib/**/*.*spec.js\""
+  },
+  "files": [
+    "lib"
+  ],
+  "main": "lib/index",
+  "types": "lib/index",
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/clangd-contexts/src/clangd-config.spec.ts
+++ b/packages/clangd-contexts/src/clangd-config.spec.ts
@@ -1,0 +1,105 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { ClangdConfigException, load, loadOrCreate, save } from './clangd-config';
+import { expect, use } from 'chai';
+import * as fs from 'fs';
+import { createTmpDir, tmpFile } from './common.spec';
+import { ClangdConfig } from '.';
+import { fail } from 'assert';
+
+/* eslint-disable no-unused-expressions */
+use(require('chai-string'));
+
+describe('clangd-config', function (): void {
+    this.beforeAll(createTmpDir);
+
+    describe('load', function (): void {
+        let clangdFile: string;
+
+        this.beforeEach(function (): void {
+            clangdFile = tmpFile('.clangd',
+                `CompileFlags:
+    CompilationDatabase: >-
+        /home/me/clangd-workspace/app/Debug_x86-64
+`);
+        });
+
+        it('load a simple config file', function (): void {
+            const simpleContent = load(clangdFile);
+            expect(simpleContent?.filePath).to.equal(clangdFile);
+            expect(simpleContent?.CompileFlags.CompilationDatabase).to.equal('/home/me/clangd-workspace/app/Debug_x86-64');
+            expect(simpleContent?.CompileFlags.Add).to.be.undefined;
+            expect(simpleContent?.CompileFlags.Remove).to.be.undefined;
+        });
+
+        it('load a non-existent config file', function (): void {
+            const nonExistent = load('no/such/.clangd');
+            expect(nonExistent).to.be.undefined;
+        });
+
+        it('loadOrCreate an existing file', function (): void {
+            const simpleContent = loadOrCreate(clangdFile);
+            expect(simpleContent.filePath).to.equal(clangdFile);
+            expect(simpleContent.CompileFlags.CompilationDatabase).to.equal('/home/me/clangd-workspace/app/Debug_x86-64');
+            expect(simpleContent.CompileFlags.Add).to.be.undefined;
+            expect(simpleContent.CompileFlags.Remove).to.be.undefined;
+        });
+
+        it('loadOrCreate a non-existent existing file', function (): void {
+            const simpleContent = loadOrCreate('no/such/.clangd');
+            expect(simpleContent.filePath).to.have.string('no/such/.clangd');
+            expect(simpleContent.CompileFlags.CompilationDatabase).to.be.undefined;
+            expect(simpleContent.CompileFlags.Add).to.be.undefined;
+            expect(simpleContent.CompileFlags.Remove).to.be.undefined;
+        });
+
+        it('load a malformed YAML file', function (): void {
+            const invalidClangdFile = tmpFile('.clangd', 'This: \'is not valid YAML content.');
+
+            try {
+                const invalidContent = load(invalidClangdFile);
+                fail(`Should have thrown ClangdConfigException instead of getting ${invalidContent}`);
+            } catch (e) {
+                expect(e).to.be.an.instanceOf(ClangdConfigException);
+                const ex = e as ClangdConfigException;
+                expect(ex.cause).to.exist;
+            }
+        });
+    });
+
+    describe('save', function (): void {
+        let clangdFile: string;
+
+        this.beforeEach(function (): void {
+            clangdFile = tmpFile('.clangd');
+        });
+
+        it('create a simple config file', function (): void {
+            const config: ClangdConfig = {
+                filePath: clangdFile,
+                CompileFlags: {
+                    CompilationDatabase: '/home/me/clangd-workspace/app/Release_x86-64'
+                }
+            };
+            save(config);
+            const simpleContent = fs.readFileSync(clangdFile, 'utf8');
+            expect(simpleContent).to.have.string('CompilationDatabase:');
+            expect(simpleContent).to.have.string('Release_x86-64');
+            expect(simpleContent).not.to.have.string('mocha', 'SourceFile path was stored');
+        });
+    });
+});

--- a/packages/clangd-contexts/src/clangd-config.ts
+++ b/packages/clangd-contexts/src/clangd-config.ts
@@ -1,0 +1,129 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import { isFile, toConfigPath } from './util/file-util';
+
+/**
+ * An exception in loading, saving, or otherwise processing a `.clangd` configuration file.
+ * It usually encapsulates a causal exception providing details of the failed operation.
+ */
+export class ClangdConfigException extends Error {
+    constructor(message: string, public readonly cause?: unknown) {
+        super(message);
+    }
+};
+
+/** Description of a project configuration as encoded in a `.clangd` file. */
+export interface ClangdConfig {
+    CompileFlags: CompileFlags;
+    filePath: string;
+}
+
+/** Representation of the compile flags property of the `.clangd` configuration. */
+export interface CompileFlags {
+    Add?: string | string[];
+    Remove?: string | string[];
+    CompilationDatabase?: string;
+}
+
+/** The name of the project's clangd configuration file to which we apply a clangd context. */
+export const CONFIG_FILE_NAME = '.clangd';
+
+/**
+ * If a `.clangd` configuration file at the given path exists, load it into a {@link ClangdConfig}.
+ *
+ * @param configPath path to the clangd configuration file or its parent directory.
+ * @returns the loaded {@link ClangdConfig} or `undefined` if the configuration file does not exist
+ * @throws {@link ClangdConfigException} on error in reading the configuration file or parsing its content
+ */
+export function load(configPath: string): ClangdConfig | undefined {
+    const configurationFile = toConfigPath(configPath);
+    if (!isFile(configurationFile)) {
+        return undefined;
+    }
+
+    try {
+        const config = yaml.load(fs.readFileSync(configurationFile, 'utf8'));
+        if (config && typeof config === 'object') {
+            return createClangdConfig(configurationFile, config);
+        }
+    } catch (e) {
+        // load throws YAMLException
+        throw new ClangdConfigException('Error parsing YAML content.', e);
+    }
+
+    return undefined;
+}
+
+/**
+ * Create a new `ClangdConfig` object.
+ *
+ * @param configurationFile the configuration file from which the configuration was loaded or to which it will be written
+ * @param configurationData the configuration data loaded from the `configurationFile`, if any. This is generically typed
+ *  because it is usually loaded from YAML and may contain data used by clangd that is not managed by this API
+ * @returns a new clangd configuration object
+ */
+function createClangdConfig(configurationFile: string, configurationData?: object): ClangdConfig {
+    const result = { CompileFlags: {}, filePath: configurationFile };
+    if (configurationData) {
+        Object.assign(result, configurationData);
+    }
+    return result;
+}
+
+/**
+ * If a `.clangd` configuration file at the given path exists, load it into a {@link ClangdConfig},
+ * or else create a new empty {@link ClangdConfig}. A new empty _file_ is not created; be sure not
+ * to {@link save} an empty configuration using the result.
+ *
+ * @param configPath path to the clangd configuration file or its parent directory
+ * @returns the loaded or new {@link ClangdConfig}
+ * @throws {@link ClangdConfigException} on error in reading an existing configuration file or parsing its content
+ *
+ * @see {@link load}, {@link save}
+ */
+export function loadOrCreate(configPath: string): ClangdConfig {
+    const configurationFile = toConfigPath(configPath);
+
+    // Propagate the exception from load, if any
+    const config = load(configurationFile) ?? createClangdConfig(configurationFile);
+    return config;
+}
+
+/**
+ * Write the content of a given {@link ClangdConfig} to its {@link ClangdConfig.filePath source file}.
+ *
+ * @param config a clangd configuration to save
+ * @throws {@link ClangdConfigException} on failure to save the config file
+ */
+export function save(config: ClangdConfig): void {
+    const filePath = config.filePath;
+    if (!filePath) {
+        throw new ClangdConfigException('Could not save config. No "filePath" has been defined.');
+    }
+
+    // Do not persist the filePath property.
+    const { filePath: SourceFile, ...persistableConfig } = config;
+    const configContent = yaml.dump(persistableConfig, { noArrayIndent: true });
+
+    try {
+        fs.writeFileSync(filePath, configContent, 'utf8');
+    } catch (e) {
+        throw new ClangdConfigException('Failed to save config.', e);
+    }
+}

--- a/packages/clangd-contexts/src/clangd-context.spec.ts
+++ b/packages/clangd-contexts/src/clangd-context.spec.ts
@@ -1,0 +1,172 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { getContext, load, setContext, setCompileFlags, unsetCompileFlags, selectContext, ClangdContextsConfig, getClangdContextsConfig, loadOrCreate, forAllProjects } from '.';
+import { expect, use } from 'chai';
+import * as fs from 'fs';
+import * as paths from 'path';
+import { createTmpDir, tmpFile } from './common.spec';
+
+/* eslint-disable no-unused-expressions */
+use(require('chai-string'));
+
+describe('clangd-context', function (): void {
+    const debug = 'DEBUG';
+    const release = 'RELEASE';
+    let configFile: string;
+    let project: string;
+
+    this.beforeAll(createTmpDir);
+
+    this.beforeEach(function (): void {
+        configFile = tmpFile('app/.clangd', path => `CompileFlags:
+    CompilationDatabase: ${paths.resolve(path, '..', debug)}
+`);
+        project = paths.dirname(configFile);
+        tmpFile(`app/${debug}/compile_commands.json`);
+        tmpFile(`app/${release}/compile_commands.json`);
+    });
+
+    describe('getContext', function (): void {
+        it('get context from .clangd file', function (): void {
+            const context = getContext(configFile)!;
+            expect(context.name).to.equal(debug);
+            expect(context.compilationDatabase).to.equal(paths.resolve(project, debug));
+        });
+    });
+
+    describe('setContext', function (): void {
+        it('set context into .clangd file', function (): void {
+            const contextDir = paths.resolve(project, release);
+            setContext(configFile, contextDir);
+
+            const content = fs.readFileSync(configFile, 'utf8');
+            expect(content).to.have.string(contextDir);
+        });
+    });
+
+    describe('setCompileFlags', function (): void {
+        it('set removed flags', function (): void {
+            setCompileFlags(configFile, undefined, ['-a', '-b', '-c']);
+
+            const context = load(configFile);
+            expect(context?.CompileFlags.Remove).to.have.members(['-a', '-b', '-c']);
+            expect(context?.CompileFlags.Add).to.be.undefined;
+        });
+
+        it('set added flags', function (): void {
+            setCompileFlags(configFile, ['-a', '-b', '-c']);
+
+            const context = load(configFile);
+            expect(context?.CompileFlags.Add).to.have.members(['-a', '-b', '-c']);
+            expect(context?.CompileFlags.Remove).to.be.undefined;
+        });
+
+        it('set both kinds of flags', function (): void {
+            setCompileFlags(configFile, ['-a', '-b', '-c'], ['-u', '-v']);
+
+            const context = load(configFile);
+            expect(context?.CompileFlags.Add).to.have.members(['-a', '-b', '-c']);
+            expect(context?.CompileFlags.Remove).to.have.members(['-u', '-v']);
+        });
+    });
+
+    describe('unsetCompileFlags', function (): void {
+        this.beforeEach(function (): void {
+            configFile = tmpFile('app/.clangd', path => `CompileFlags:
+    Add:
+        - -a
+        - -b
+        - -c
+    Remove:
+        - -u
+        - -v
+    CompilationDatabase: ${paths.resolve(path, '..', debug)}
+`);
+        });
+
+        it('unset removed flags', function (): void {
+            unsetCompileFlags(configFile, ['-u']);
+
+            const context = load(configFile);
+            expect(context?.CompileFlags.Remove).to.have.members(['-v']);
+        });
+
+        it('unset added flags', function (): void {
+            unsetCompileFlags(configFile, ['-b']);
+
+            const context = load(configFile);
+            expect(context?.CompileFlags.Add).to.have.members(['-a', '-c']);
+        });
+
+        it('unset all flags', function (): void {
+            unsetCompileFlags(configFile, ['-a', '-b', '-c', '-u', '-v']);
+
+            const context = load(configFile);
+            expect(context?.CompileFlags.Add).to.be.undefined;
+            expect(context?.CompileFlags.Remove).to.be.undefined;
+        });
+    });
+
+    describe('workspace-aware functions', function (): void {
+        let workspaceConfigFile: string;
+        let workspaceConfig: ClangdContextsConfig;
+        let appProject: string;
+        let libProject: string;
+
+        this.beforeAll(function (): void {
+            workspaceConfigFile = tmpFile('.clangd-contexts',
+                `{
+"workspaceName": "Test Workspace",
+"projects": [
+    {
+        "path": "app",
+        "contextDirs": "flat"
+    },
+    {
+        "path": "lib",
+        "contextDirs": "flat"
+    }
+]
+}`);
+
+            tmpFile(`app/${debug}/compile_commands.json`, '');
+            tmpFile(`app/${release}/compile_commands.json`, '');
+            tmpFile(`lib/${debug}/compile_commands.json`, '');
+            tmpFile(`lib/${release}/compile_commands.json`, '');
+
+            workspaceConfig = getClangdContextsConfig(workspaceConfigFile)!;
+            appProject = paths.join(workspaceConfig.path, 'app');
+            libProject = paths.join(workspaceConfig.path, 'lib');
+        });
+
+        it('selectContext', function (): void {
+            selectContext(workspaceConfig, release);
+
+            const appContext = loadOrCreate(appProject);
+            expect(appContext.CompileFlags.CompilationDatabase).to.have.string(release);
+            const libContext = loadOrCreate(libProject);
+            expect(libContext.CompileFlags.CompilationDatabase).to.have.string(release);
+        });
+
+        it('forAllProjects', function (): void {
+            const names: string[] = [];
+
+            forAllProjects(workspaceConfig, proj => names.push(typeof proj === 'string' ? proj : proj.filePath));
+            expect(names).to.have.members([appProject, libProject]);
+        });
+    });
+});

--- a/packages/clangd-contexts/src/clangd-context.ts
+++ b/packages/clangd-contexts/src/clangd-context.ts
@@ -1,0 +1,198 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import * as path from 'path';
+import { ClangdConfig, load, loadOrCreate, save } from './clangd-config';
+import { ClangdContextsConfig } from './clangd-contexts-config';
+import { isDirectory } from './util/file-util';
+import { asArray } from './util/maybe-array';
+
+/** Description of a clangd context. */
+export interface ClangdContext {
+    name: string;
+    compilationDatabase: string;
+}
+
+/**
+ * Set the context selected in a project. The `.clangd` file will be updated to
+ * refer to the given context's compilation database.
+ *
+ * @param configurationInput the clangd configuration to update, either the `.clangd` file's path or its content
+ * @param contextDirectory the directory that contains the compilation database file
+ * @throws {@link ClangdConfigException} on error in saving the updated configuration file
+ */
+export function setContext(configurationInput: string | ClangdConfig, contextDirectory: string): void {
+    const configuration = typeof configurationInput === 'string' ? loadOrCreate(configurationInput) : configurationInput;
+    configuration.CompileFlags.CompilationDatabase = contextDirectory;
+    save(configuration);
+}
+
+/**
+ * Retrieve the active context of the given `.clangd` configuration file.
+ *
+ * @param configPath the clangd context file to read
+ * @return the context-relevant content of the file, or `undefined` if the file does not exist
+ * @throws {@link ClangdConfigException} on error in loading an existing configuration file
+ */
+export function getContext(configPath: string): ClangdContext | undefined {
+    const config = load(configPath);
+
+    if (config && config.CompileFlags.CompilationDatabase) {
+        return {
+            name: path.relative(path.dirname(config.filePath), config.CompileFlags.CompilationDatabase),
+            compilationDatabase: config.CompileFlags.CompilationDatabase,
+        };
+    }
+
+    return undefined;
+}
+
+/**
+ * In the given `.clangd` file, specify flags to add to and/or remove from invocations of the `clang` compiler
+ * in clangd's analysis.
+ *
+ * @param configurationInput the clangd configuration to update, either the `.clangd` file path or its content
+ * @param addFlags an optional array of flags to add to the list of flags added to the `clang` command-line
+ * @param removeFlags an optional array of flags to add to the list of flags removed from the `clang` command-line
+ * @throws {@link ClangdConfigException} on error in saving the updated configuration file
+ */
+export function setCompileFlags(configurationInput: string | ClangdConfig, addFlags?: string[], removeFlags?: string[]): void {
+    const configuration = typeof configurationInput === 'string' ? loadOrCreate(configurationInput) : configurationInput;
+
+    if (addFlags) {
+        configuration.CompileFlags.Add = includeFlags(addFlags, configuration.CompileFlags.Add);
+    }
+    if (removeFlags) {
+        configuration.CompileFlags.Remove = includeFlags(removeFlags, configuration.CompileFlags.Remove);
+    }
+
+    save(configuration);
+}
+
+/**
+ * Remove from the given `.clangd` file some flags that are currently added or removed from invocations of the `clang` compiler
+ * in clangd's analysis. In the `.clangd` file, any given flag will generally be either in the `Add` list or the `Remove` list.
+ * This function ensures that the flags specified will not appear in either list in the updated `.clangd` file.
+ *
+ * @param configurationInput the clangd configuration to update, either the `.clangd` file path or its content
+ * @param flags an optional array of flags to remove from the lists of flags added to and removed from the `clang` command-line
+ * @throws {@link ClangdConfigException} on error in saving the updated configuration file
+ */
+export function unsetCompileFlags(configurationInput: string | ClangdConfig, flags?: string[]): void {
+    const configuration = typeof configurationInput === 'string' ? loadOrCreate(configurationInput) : configurationInput;
+
+    if (flags && configuration.CompileFlags.Add) {
+        configuration.CompileFlags.Add = excludeFlags(flags, configuration.CompileFlags.Add);
+        if (configuration.CompileFlags.Add.length === 0) {
+            delete configuration.CompileFlags.Add;
+        }
+    }
+    if (flags && configuration.CompileFlags.Remove) {
+        configuration.CompileFlags.Remove = excludeFlags(flags, configuration.CompileFlags.Remove);
+        if (configuration.CompileFlags.Remove.length === 0) {
+            delete configuration.CompileFlags.Remove;
+        }
+    }
+
+    save(configuration);
+}
+
+/**
+ * Ensure that an array of flags includes some required flags.
+ *
+ * @param newFlags flags to ensure are included along with the `currentFlags`
+ * @param currentFlags an existing single flag or array of flags
+ * @returns a new array based on the `currentFlags` that includes the `newFlags`
+ */
+function includeFlags(newFlags: string[], currentFlags?: string | string[]): string[] {
+    const base = asArray(currentFlags ?? []);
+    return Array.from(new Set(base.concat(newFlags)));
+}
+
+/**
+ * Ensure that an array of flags does not include some unwanted flags.
+ *
+ * @param flagsToRemove flags to ensure are excluded from the array of `currentFlags`
+ * @param currentFlags an existing single flag or array of flags
+ * @returns a new array based on the `currentFlags` that does not include any of the `flagsToRemove`
+ */
+function excludeFlags(flagsToRemove: string[], currentFlags?: string | string[]): string[] {
+    const result = new Set(asArray(currentFlags ?? []));
+    flagsToRemove.forEach(flag => result.delete(flag));
+    return Array.from(result);
+}
+
+/**
+ * Activate a named context in all of the projects that have a context of that name.
+ * Any project that does not have the context is left unchanged.
+ *
+ * @param contextsConfig the projects from the `.clangd-contexts` file
+ * @param contextName the context to active in the projects
+ */
+export function selectContext(contextsConfig: ClangdContextsConfig, contextName: string): void {
+    contextsConfig.projects.forEach(proj => {
+        const configDir = contextsConfig.toContextDir(proj, contextName);
+
+        // Not necessarily every project actually has this context defined
+        if (isDirectory(configDir)) {
+            setContext(contextsConfig.getClangdConfig(proj), configDir);
+        }
+    });
+}
+
+/**
+ * List the distinct context names across all projects.
+ *
+ * @param contextsConfig the clangd workspace configuration from the `.clangd-contexts` file
+ */
+export function listContexts(contextsConfig: ClangdContextsConfig): void {
+    contextsConfig.getClangdContexts().forEach(context => console.log(context));
+}
+
+/**
+ * List the projects in the workspace.
+ *
+ * @param contextsConfig the clangd workspace configuration from the `.clangd-contexts` file
+ * @param baseDir a directory relative to which the output directory paths are deresolved. For example, in a
+ *   CLI tool this might be the current working directory. If omitted, absolute paths are output
+ */
+export function listProjects(contextsConfig: ClangdContextsConfig, baseDir?: string): void {
+    const deresolve: (p: string) => string = baseDir ? p => {
+        const outputPath = path.relative(baseDir, p);
+        const normalizedOutputPath = outputPath === '' ? '.' : outputPath;
+        return normalizedOutputPath + path.sep;
+    } : p => path.resolve(contextsConfig.path, p);
+
+    forAllProjects(contextsConfig, proj => {
+        const projectPath = typeof proj === 'string' ? proj : path.dirname(proj.filePath);
+        const outputPath = deresolve(projectPath);
+        console.log(outputPath);
+    });
+}
+
+/**
+ * Perform some action on all valid project directories.
+ *
+ * @param contextsConfig the clangd workspace configuration from the `.clangd-contexts` file
+ * @param action an action to perform on each project directory
+ */
+export function forAllProjects(contextsConfig: ClangdContextsConfig, action: (configurationInput: string | ClangdConfig) => void): void {
+    contextsConfig.getClangdProjects().forEach(project => {
+        if (isDirectory(project)) {
+            action(project);
+        }
+    });
+}

--- a/packages/clangd-contexts/src/clangd-contexts-config.spec.ts
+++ b/packages/clangd-contexts/src/clangd-contexts-config.spec.ts
@@ -1,0 +1,109 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { getClangdContextsConfig } from '.';
+import { expect, use } from 'chai';
+import * as paths from 'path';
+import * as mkdirp from 'mkdirp';
+import * as os from 'os';
+import { createTmpDir, tmpFile } from './common.spec';
+import rimraf = require('rimraf');
+
+/* eslint-disable no-unused-expressions */
+use(require('chai-string'));
+
+describe('clangd-contexts-config', function (): void {
+    let configFile: string;
+
+    this.beforeAll(createTmpDir);
+
+    this.beforeEach(function (): void {
+        configFile = tmpFile('.clangd-contexts',
+            `{
+"workspaceName": "Theia Clangd Contexts Test",
+"projects": [
+    {
+        "path": "app",
+        "contextDirs": "nested"
+    },
+    {
+        "path": "lib",
+        "contextDirs": "flat"
+    }
+]
+}`);
+    });
+
+    describe('getClangdContextsConfig', function (): void {
+        it('load a simple config file', function (): void {
+            const simpleConfig = getClangdContextsConfig(configFile);
+            expect(simpleConfig?.path).to.equal(paths.dirname(configFile));
+            expect(simpleConfig?.workspaceName).to.equal('Theia Clangd Contexts Test');
+            expect(simpleConfig?.projects).to.have.nested.property('[0].contextDirs', 'nested');
+            expect(simpleConfig?.projects).to.have.nested.property('[1].path', 'lib');
+        });
+
+        it('search up the parent directories', function (): void {
+            const cwd = paths.resolve(configFile, '..', 'some', 'nested', 'dir');
+            mkdirp.sync(cwd);
+            const simpleConfig = getClangdContextsConfig(cwd);
+            expect(simpleConfig?.path).to.equal(paths.dirname(configFile));
+        });
+
+        it('load a non-existent config file', function (): void {
+            const simpleConfig = getClangdContextsConfig(os.tmpdir());
+            expect(simpleConfig).to.be.undefined;
+        });
+    });
+
+    describe('ClangdContextsConfig', function (): void {
+        this.afterEach(function (): void {
+            rimraf.sync(paths.resolve(configFile, '..', 'app'));
+            rimraf.sync(paths.resolve(configFile, '..', 'lib'));
+        });
+
+        it('getClangdProjects', function (): void {
+            const projects = getClangdContextsConfig(configFile)?.getClangdProjects();
+            const absoluteDirs = ['app', 'lib'].map(dir => paths.resolve(configFile, '..', dir));
+            expect(projects).to.have.members(absoluteDirs);
+        });
+
+        it('getClangdContexts (no contexts)', function (): void {
+            const contexts = getClangdContextsConfig(configFile)?.getClangdContexts();
+            expect(contexts).to.be.empty;
+        });
+
+        it('getClangdContexts', function (): void {
+            // These are nested
+            tmpFile('app/Debug/x86-64/compile_commands.json', '');
+            tmpFile('app/Release/x86-64/compile_commands.json', '');
+            // And these are flat
+            tmpFile('lib/Debug_x86-64/compile_commands.json', '');
+            tmpFile('lib/Release_x86-64/compile_commands.json', '');
+            const contexts = getClangdContextsConfig(configFile)?.getClangdContexts();
+            expect(contexts).to.have.members(['Debug/x86-64', 'Release/x86-64', 'Debug_x86-64', 'Release_x86-64']);
+        });
+
+        it('getClangdContexts (uniqueness)', function (): void {
+            tmpFile('app/Debug_x86-64/compile_commands.json', '');
+            tmpFile('app/Release_x86-64/compile_commands.json', '');
+            tmpFile('lib/Debug_x86-64/compile_commands.json', '');
+            tmpFile('lib/Release_x86-64/compile_commands.json', '');
+            const contexts = getClangdContextsConfig(configFile)?.getClangdContexts();
+            expect(contexts).to.have.members(['Debug_x86-64', 'Release_x86-64']);
+        });
+    });
+});

--- a/packages/clangd-contexts/src/clangd-contexts-config.ts
+++ b/packages/clangd-contexts/src/clangd-contexts-config.ts
@@ -1,0 +1,195 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { readdirSync, readFileSync, existsSync } from 'fs';
+import * as path from 'path';
+import { ClangdConfig, loadOrCreate } from '.';
+import { isDirectory, toPortablePath } from './util/file-util';
+
+export const COMPILE_COMMANDS_FILE = 'compile_commands.json';
+const CONFIG_FILE = '.clangd-contexts';
+
+export interface ClangdProjectConfig {
+    /** The workspace-relative path to the project. */
+    path: string;
+    /** The layout of context directories within the project. */
+    contextDirs: 'flat' | 'nested';
+}
+
+export interface ClangdContextsConfig {
+    /** The directory path containing the `.clangd-contexts` file describing this configuration. */
+    path: string;
+    /** An optional name for the clangd workspace overall. */
+    workspaceName?: string;
+    /** Configuration of projects within the scope of the workspace. */
+    projects: ClangdProjectConfig[];
+
+    /** Query the directory paths of the projects. */
+    getClangdProjects(): string[];
+
+    /** Query the names of all distinct contexts across all known projects. */
+    getClangdContexts(): string[];
+
+    /**
+     * Load the clangd configuration of a project.
+     *
+     * @param projectConfig a project for which to compute its absolute directory path
+     * @returns its clangd configuration
+     */
+    getClangdConfig(projectConfig: ClangdProjectConfig): ClangdConfig;
+
+    /**
+     * Compute the directory that contains the `compile_commands.json` database of the named context of a project.
+     *
+     * @param projectConfig a project for which to compute a context directory path
+     * @param contextName the context name
+     * @returns the absolute directory path of the named context in the project
+     */
+    toContextDir(projectConfig: ClangdProjectConfig, contextName: string): string;
+}
+
+class ClangdContextsConfigImpl implements ClangdContextsConfig {
+    path: string;
+    workspaceName?: string;
+    projects: ClangdProjectConfig[];
+
+    constructor(clangdContextsFile: string) {
+        try {
+            const data = JSON.parse(readFileSync(clangdContextsFile, 'utf8'));
+            Object.assign(this, data);
+        } catch (e) {
+            console.log(`Failed to load ${clangdContextsFile}:`, e);
+            throw e;
+        }
+        this.path = path.dirname(clangdContextsFile);
+
+        this.projects.forEach(this.initProjectConfig.bind(this));
+    }
+
+    /**
+     * Initialize the defaults in a project configuration.
+     *
+     * @param projectConfig the context configuration to initialize
+     * @returns the initialized context configuration
+     */
+    private initProjectConfig(projectConfig: ClangdProjectConfig): ClangdProjectConfig {
+        if (!projectConfig.contextDirs) {
+            projectConfig.contextDirs = 'flat';
+        }
+        return projectConfig;
+    }
+
+    getClangdProjects(): string[] {
+        return this.projects.map(proj => path.resolve(this.path, proj.path));
+    }
+
+    getClangdContexts(): string[] {
+        const result: Set<string> = new Set();
+
+        this.projects.forEach(proj => {
+            const projPath = path.resolve(this.path, proj.path);
+
+            if (proj.contextDirs === 'flat') {
+                this.collectFlatClangdContexts(projPath, result);
+            } else {
+                this.collectNestedClangdContexts(projPath, result);
+            }
+        });
+
+        return Array.from(result);
+    }
+
+    getClangdConfig(projectConfig: ClangdProjectConfig): ClangdConfig {
+        return loadOrCreate(path.join(this.path, projectConfig.path));
+    }
+
+    toContextDir(projectConfig: ClangdProjectConfig, contextName: string): string {
+        return path.join(this.path, projectConfig.path, contextName);
+    }
+
+    private collectFlatClangdContexts(projectDir: string, contexts: Set<string>): void {
+        const listing = isDirectory(projectDir) ? readdirSync(projectDir) : [];
+        listing.forEach(entry => {
+            const contextDir = path.join(projectDir, entry);
+            if (isDirectory(contextDir)) {
+                // Does it have a compilation database?
+                const ccFile = path.join(contextDir, COMPILE_COMMANDS_FILE);
+                if (existsSync(ccFile)) {
+                    contexts.add(entry);
+                }
+            }
+        });
+    }
+
+    private collectNestedClangdContexts(projectDir: string, contexts: Set<string>): void {
+        this.collectNestedClangdContextsRecursive(projectDir, [], contexts);
+    }
+
+    private collectNestedClangdContextsRecursive(projectRoot: string, contextPath: string[], contexts: Set<string>): void {
+        const possibleContextDir = path.join(...contextPath);
+        const qualifiedContextDir = path.join(projectRoot, ...contextPath);
+
+        // Use a uniform, POSIX-like segmentation of the path on all platforms, including Windows
+        const possibleContextName = toPortablePath(possibleContextDir);
+
+        // Check for compilation database in a context below the root. At the root, the context name would be empty
+        const ccFile = path.join(qualifiedContextDir, COMPILE_COMMANDS_FILE);
+        if (contextPath.length > 0 && existsSync(ccFile)) {
+            // This is a context directory
+            contexts.add(possibleContextName);
+        }
+
+        if (isDirectory(qualifiedContextDir)) {
+            // Look deeper for context directories
+            const listing = readdirSync(qualifiedContextDir);
+            listing.forEach(entry => {
+                const nestedDir = path.join(qualifiedContextDir, entry);
+                if (isDirectory(nestedDir)) {
+                    this.collectNestedClangdContextsRecursive(projectRoot, [...contextPath, entry], contexts);
+                }
+            });
+        }
+    }
+}
+
+/**
+ * Find and load the `.clangd-contexts` file that configures clangd contexts for projects in the given
+ * `directory`. Searches that `directory` and up its parent chain until a `.clangd-contexts`
+ * file is found or else the search is exhausted.
+ *
+ * @param directory the directory in which to search for the `.clangd-contexts` file
+ * @returns the loaded `.clangd-contexts` configuration if it is found
+ */
+export function getClangdContextsConfig(directory: string): ClangdContextsConfig | undefined {
+    for (; ;) {
+        const maybeConfig = path.join(directory, CONFIG_FILE);
+        if (existsSync(maybeConfig)) {
+            const result = new ClangdContextsConfigImpl(maybeConfig);
+            return result;
+        }
+
+        // Continue searching up the directory hierarchy
+        const parent = path.dirname(directory);
+        if (parent === directory) {
+            // This happens at the root
+            break;
+        } else {
+            directory = parent;
+        }
+    }
+
+    return undefined;
+}

--- a/packages/clangd-contexts/src/common.spec.ts
+++ b/packages/clangd-contexts/src/common.spec.ts
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import * as fs from 'fs';
+import * as paths from 'path';
+import * as rimraf from 'rimraf';
+import * as mkdirp from 'mkdirp';
+import * as os from 'os';
+
+/* eslint-disable no-unused-expressions */
+
+let tmpDir: string;
+
+type ContentInitializer = string | ((resolvedPath: string) => string);
+
+export const tmpFile = (path: string, content?: ContentInitializer) => {
+    const result = paths.resolve(tmpDir, path);
+    if (content !== undefined) {
+        mkdirp.sync(paths.dirname(result));
+
+        const initialContent = typeof content === 'string' ? content : content(result);
+        fs.writeFileSync(result, initialContent, 'utf8');
+    }
+    return result;
+};
+
+export const createTmpDir = () => {
+    if (!tmpDir) {
+        tmpDir = fs.mkdtempSync(paths.join(os.tmpdir(), 'mocha'));
+        const cleanUp = (exit: boolean) => () => {
+            rimraf.sync(tmpDir);
+            exit && process.exit();
+        };
+        process.on('exit', cleanUp(false));
+        process.on('SIGINT', cleanUp(true));
+        process.on('uncaughtException', cleanUp(true));
+    }
+};

--- a/packages/clangd-contexts/src/index.ts
+++ b/packages/clangd-contexts/src/index.ts
@@ -1,0 +1,20 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+export * from './clangd-config';
+export * from './clangd-context';
+export * from './clangd-contexts-config';
+export { isDirectory, isFile } from './util/file-util';

--- a/packages/clangd-contexts/src/util/file-util.spec.ts
+++ b/packages/clangd-contexts/src/util/file-util.spec.ts
@@ -1,0 +1,92 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { isFile, isDirectory, toConfigPath, toPortablePath } from './file-util';
+import { expect, use } from 'chai';
+
+import * as paths from 'path';
+
+use(require('chai-string'));
+
+/* eslint-disable no-unused-expressions */
+describe('file-util', function (): void {
+    describe('isFile', function (): void {
+        it('handles files and directories that exist', function (): void {
+            const fromFile = isFile('package.json');
+            expect(fromFile).to.be.true;
+
+            const fromDirectory = isFile(fromPortablePath('src/util'));
+            expect(fromDirectory).to.be.false;
+        });
+
+        it('handles paths that do not exist', function (): void {
+            const fromMissing = isFile(fromPortablePath('src/no/such/path'));
+            expect(fromMissing).to.be.false;
+        });
+    });
+
+    describe('isDirectory', function (): void {
+        it('handles files and directories that exist', function (): void {
+            const fromFile = isDirectory('package.json');
+            expect(fromFile).to.be.false;
+
+            const fromDirectory = isDirectory(fromPortablePath('src/util'));
+            expect(fromDirectory).to.be.true;
+        });
+
+        it('handles paths that do not exist', function (): void {
+            const fromMissing = isDirectory(fromPortablePath('src/no/such/path'));
+            expect(fromMissing).to.be.false;
+        });
+    });
+
+    describe('toConfigPath', function (): void {
+        it('handles exact file', function (): void {
+            const fromExactFile = toConfigPath(fromPortablePath('some/path/.clangd'));
+            expect(fromExactFile).to.equal(fromPortablePath('some/path/.clangd'));
+        });
+
+        // With a directory input, the result is resolved to an absolute path
+        it('handles directory', function (): void {
+            const fromDirectory = toConfigPath(fromPortablePath('some/path'));
+            expect(fromDirectory).to.endWith(fromPortablePath('/some/path/.clangd'));
+
+            const fromDirectoryWithTrailingSlash = toConfigPath(fromPortablePath('some/path/'));
+            expect(fromDirectoryWithTrailingSlash).to.endWith(fromPortablePath('/some/path/.clangd'));
+        });
+
+        // With a directory input, the result is resolved to an absolute path
+        it('handles path that happens to have .clangd extension', function (): void {
+            const fromTrickyPath = toConfigPath(fromPortablePath('some/path/project.clangd'));
+            expect(fromTrickyPath).to.endWith(fromPortablePath('/some/path/project.clangd/.clangd'));
+        });
+    });
+
+    describe('toPortablePath', function (): void {
+        it('handles platform-specific path', function (): void {
+            const pathSpec = 'this/is/a/path.c';
+            const platformSpecificPath = fromPortablePath(pathSpec);
+            expect(toPortablePath(platformSpecificPath)).to.equal(pathSpec);
+        });
+    });
+});
+
+function fromPortablePath(path: string): string {
+    if (paths.sep !== '/') {
+        return path.replace(/\/+/g, paths.sep);
+    }
+    return path;
+}

--- a/packages/clangd-contexts/src/util/file-util.ts
+++ b/packages/clangd-contexts/src/util/file-util.ts
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import * as fs from 'fs';
+import * as paths from 'path';
+import { CONFIG_FILE_NAME } from '../clangd-config';
+
+/** A regex that matches possibly repeated host-platform path separator. */
+const pathSepRegex = new RegExp(`\\${paths.sep}+`, 'g'); // Escape the sep, whether '\' or '/', for safety
+
+/**
+ * Queries whether a given `path` represents a file.
+ *
+ * @param path a path to test
+ * @returns `true` if the `path` is a file, `false` otherwise
+ */
+export function isFile(path: string): boolean {
+    try {
+        return fs.statSync(path).isFile();
+    } catch (error) {
+        return false;
+    }
+}
+
+/**
+ * Queries whether a given `path` represents a directory.
+ *
+ * @param path a path to test
+ * @returns `true` if the `path` is a directory, `false` otherwise
+ */
+export function isDirectory(path: string): boolean {
+    try {
+        return fs.statSync(path).isDirectory();
+    } catch (error) {
+        return false;
+    }
+}
+
+/**
+ * Resolve a path to a _clangd_ configuration file.
+ *
+ * @param filePath a path that may or may not already identify a `.clangd` file
+ * @returns the `filePath` if it is a `.clangd` file, otherwise a path that resolves a `.clangd` file as
+ * a child or sibling of the `filePath` according to whether it is a directory or file, respectively
+ */
+export function toConfigPath(filePath: string): string {
+    return paths.basename(filePath) === CONFIG_FILE_NAME ? filePath : paths.resolve(filePath, CONFIG_FILE_NAME);
+}
+
+/**
+ * Obtain a uniform representation of a `path` regardless of host platform. This should only be used for relative paths
+ * (so not involving drive letters on Windows platform) to obtain an identifier or name used for some
+ * other purpose than accessing the filesystem.
+ *
+ * @param path a path in the host filesystem
+ * @returns a representation of the `path` using `/` to separate segments
+ */
+export function toPortablePath(path: string): string {
+    if (paths.sep !== '/') {
+        return path.split(pathSepRegex).join('/');
+    }
+    return path;
+}

--- a/packages/clangd-contexts/src/util/maybe-array.spec.ts
+++ b/packages/clangd-contexts/src/util/maybe-array.spec.ts
@@ -1,0 +1,39 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+import { asArray } from './maybe-array';
+import { expect } from 'chai';
+
+/* eslint-disable no-unused-expressions */
+describe('maybe-array', function (): void {
+    it('handles scalar value', function (): void {
+        const fromScalar = asArray('hello');
+        expect(fromScalar).to.be.an('array').that.has.members(['hello']);
+    });
+
+    it('handles array values', function (): void {
+        const fromArray = asArray(['hello', 'world']);
+        expect(fromArray).to.be.an('array').that.has.ordered.members(['hello', 'world']);
+
+        const fromEmptyArray = asArray([]);
+        expect(fromEmptyArray).to.be.an('array').that.is.empty;
+    });
+
+    it('handles undefined', function (): void {
+        const fromUndefined = asArray(undefined);
+        expect(fromUndefined).to.be.an('array').that.has.members([undefined]);
+    });
+});

--- a/packages/clangd-contexts/src/util/maybe-array.ts
+++ b/packages/clangd-contexts/src/util/maybe-array.ts
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2021 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ *******************************************************************************/
+
+export type MaybeArray<T> = T | T[];
+
+/**
+ * Coerce an object as an array.
+ *
+ * @param maybe an object or an array
+ * @returns an array of the base type of the `maybe` argument
+ */
+export function asArray<T>(maybe: MaybeArray<T>): T[] {
+    return Array.isArray(maybe) ? maybe : [maybe];
+}

--- a/packages/cpp-debug/package.json
+++ b/packages/cpp-debug/package.json
@@ -42,7 +42,7 @@
     "build": "tsc -b compile.tsconfig.json",
     "watch": "tsc -p compile.tsconfig.json -w",
     "clean": "rimraf lib *.tsbuildinfo && rimraf .eslintcache && rimraf .nyc_output coverage",
-    "test": "mocha --opts ../../configs/mocha.opts \"./lib/**/*.*spec.js\""
+    "test": "mocha --config ../../configs/mocharc.json \"./lib/**/*.*spec.js\""
   },
   "devDependencies": {
     "@types/long": "^4.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,12 @@
       "@theia/cpp-debug/lib/*": [
         "packages/cpp-debug/src/*"
       ],
+      "@theia/clangd-contexts-cli/lib/*": [
+        "examples/clangd-contexts-cli/src/*"
+      ],
+      "@theia/clangd-contexts/lib/*": [
+        "packages/clangd-contexts/src/*"
+      ],
       "@cpp-debug/example-electron/*": [
         "examples/electron/*"
       ],
@@ -33,6 +39,9 @@
       ],
       "@theia/eslint-plugin/*": [
         "dev-packages/eslint-plugin/*"
+      ],
+      "theia-clangd-contexts-ext/lib/*": [
+        "examples/clangd-contexts-ext/src/*"
       ]
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2516,6 +2516,11 @@
     moment "2.24.0"
     valid-filename "^2.0.1"
 
+"@tootallnate/once@1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
+  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
 "@types/base64-arraybuffer@0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@types/base64-arraybuffer/-/base64-arraybuffer-0.1.0.tgz#739eea0a974d13ae831f96d97d882ceb0b187543"
@@ -2540,6 +2545,18 @@
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.2.tgz#f65d3d6389e01eeb458bd54dc8f52b95a9463bc8"
   integrity sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==
+
+"@types/chai-string@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@types/chai-string/-/chai-string-1.4.2.tgz#0f116504a666b6c6a3c42becf86634316c9a19ac"
+  integrity sha512-ld/1hV5qcPRGuwlPdvRfvM3Ka/iofOk2pH4VkasK4b1JJP1LjNmWWn0LsISf6RRzyhVOvs93rb9tM09e+UuF8Q==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.0.tgz#23509ebc1fa32f1b4d50d6a66c4032d5b8eaabdc"
+  integrity sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==
 
 "@types/chai@^4.2.7":
   version "4.2.21"
@@ -2622,6 +2639,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/fs-extra@^9.0.13":
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
+  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@*":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz#ea59e21d2ee5c517914cb4bc8e4153b99e566672"
@@ -2629,6 +2653,11 @@
   dependencies:
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/js-yaml@^4.0.2":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
+  integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
 
 "@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8":
   version "7.0.9"
@@ -2726,6 +2755,11 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
   integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
 
+"@types/mocha@^8.2.2":
+  version "8.2.3"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.2.3.tgz#bbeb55fbc73f28ea6de601fbfa4613f58d785323"
+  integrity sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==
+
 "@types/multer@^1.4.7":
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/@types/multer/-/multer-1.4.7.tgz#89cf03547c28c7bbcc726f029e2a76a7232cc79e"
@@ -2741,7 +2775,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@12", "@types/node@>= 8", "@types/node@^12.0.12":
+"@types/node@*", "@types/node@12", "@types/node@14.x", "@types/node@>= 8", "@types/node@^12.0.12", "@types/node@~12":
   version "12.20.20"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.20.tgz#ce3d6c13c15c5e622a85efcd3a1cb2d9c7fa43a6"
   integrity sha512-kqmxiJg4AT7rsSPIhO6eoBIx9mNwwpeH42yjtgQh6X2ANSpLpvToMXv+LMFdfxpwG1FZXZ41OGZMiUAtbBLEvg==
@@ -2905,6 +2939,11 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-7.0.5.tgz#b1d2f772142a301538fae9bdf9cf15b9f2573a29"
   integrity sha512-hKB88y3YHL8oPOs/CNlaXtjWn93+Bs48sDQR37ZUqG2tLeCS7EA1cmnkKsuQsub9OKEB/y/Rw9zqJqqNSbqVlQ==
 
+"@types/vscode@^1.59.0":
+  version "1.63.1"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.63.1.tgz#b40f9f18055e2c9498ae543d18c59fbd6ef2e8a3"
+  integrity sha512-Z+ZqjRcnGfHP86dvx/BtSwWyZPKQ/LBdmAVImY82TphyjOw2KgTKcp7Nx92oNwCTsHzlshwexAG/WiY2JuUm3g==
+
 "@types/write-json-file@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@types/write-json-file/-/write-json-file-2.2.1.tgz#74155aaccbb0d532be21f9d66bebc4ea875a5a62"
@@ -2938,6 +2977,20 @@
     "@typescript-eslint/experimental-utils" "4.29.3"
     lodash "^4.17.21"
 
+"@typescript-eslint/eslint-plugin@^4.26.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
+  integrity sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "4.33.0"
+    "@typescript-eslint/scope-manager" "4.33.0"
+    debug "^4.3.1"
+    functional-red-black-tree "^1.0.1"
+    ignore "^5.1.8"
+    regexpp "^3.1.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/eslint-plugin@^4.8.1":
   version "4.29.3"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.3.tgz#95cb8029a8bd8bd9c7f4ab95074a7cb2115adefa"
@@ -2963,6 +3016,18 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
+"@typescript-eslint/experimental-utils@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz#6f2a786a4209fa2222989e9380b5331b2810f7fd"
+  integrity sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==
+  dependencies:
+    "@types/json-schema" "^7.0.7"
+    "@typescript-eslint/scope-manager" "4.33.0"
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/typescript-estree" "4.33.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
 "@typescript-eslint/experimental-utils@^2.19.2 || ^3.0.0":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz#e179ffc81a80ebcae2ea04e0332f8b251345a686"
@@ -2973,6 +3038,16 @@
     "@typescript-eslint/typescript-estree" "3.10.1"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
+
+"@typescript-eslint/parser@^4.26.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
+  integrity sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "4.33.0"
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/typescript-estree" "4.33.0"
+    debug "^4.3.1"
 
 "@typescript-eslint/parser@^4.8.1":
   version "4.29.3"
@@ -2992,6 +3067,14 @@
     "@typescript-eslint/types" "4.29.3"
     "@typescript-eslint/visitor-keys" "4.29.3"
 
+"@typescript-eslint/scope-manager@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz#d38e49280d983e8772e29121cf8c6e9221f280a3"
+  integrity sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==
+  dependencies:
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/visitor-keys" "4.33.0"
+
 "@typescript-eslint/types@3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
@@ -3001,6 +3084,11 @@
   version "4.29.3"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.3.tgz#d7980c49aef643d0af8954c9f14f656b7fd16017"
   integrity sha512-s1eV1lKNgoIYLAl1JUba8NhULmf+jOmmeFO1G5MN/RBCyyzg4TIOfIOICVNC06lor+Xmy4FypIIhFiJXOknhIg==
+
+"@typescript-eslint/types@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
+  integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
 
 "@typescript-eslint/typescript-estree@3.10.1":
   version "3.10.1"
@@ -3029,6 +3117,19 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz#0dfb51c2908f68c5c08d82aefeaf166a17c24609"
+  integrity sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==
+  dependencies:
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/visitor-keys" "4.33.0"
+    debug "^4.3.1"
+    globby "^11.0.3"
+    is-glob "^4.0.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/visitor-keys@3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz#cd4274773e3eb63b2e870ac602274487ecd1e931"
@@ -3043,6 +3144,19 @@
   dependencies:
     "@typescript-eslint/types" "4.29.3"
     eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz#2a22f77a41604289b7a186586e9ec48ca92ef1dd"
+  integrity sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==
+  dependencies:
+    "@typescript-eslint/types" "4.33.0"
+    eslint-visitor-keys "^2.0.0"
+
+"@ungap/promise-all-settled@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
+  integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
 "@vscode/codicons@^0.0.21":
   version "0.0.21"
@@ -3329,7 +3443,7 @@ ansi-colors@3.2.3:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
   integrity sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==
 
-ansi-colors@^4.1.1:
+ansi-colors@4.1.1, ansi-colors@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
@@ -3427,6 +3541,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -3620,6 +3739,14 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+
+azure-devops-node-api@^11.0.1:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/azure-devops-node-api/-/azure-devops-node-api-11.1.0.tgz#ea3ca49de8583b0366d000f3c3f8a75b8104055f"
+  integrity sha512-6/2YZuf+lJzJLrjXNYEA5RXAkMCb8j/4VcHD0qJQRsgG/KsRMYo0HgDh0by1FGHyZkQWY5LmQyJqCwRVUB3Y7Q==
+  dependencies:
+    tunnel "0.0.6"
+    typed-rest-client "^1.8.4"
 
 babel-code-frame@^6.11.0:
   version "6.26.0"
@@ -3824,6 +3951,11 @@ body-parser@1.19.0, body-parser@^1.17.2, body-parser@^1.18.3:
     qs "6.7.0"
     raw-body "2.4.0"
     type-is "~1.6.17"
+
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
 boolean@^3.0.1:
   version "3.1.4"
@@ -4139,6 +4271,11 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
+camelcase@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.1.tgz#250fd350cfd555d0d2160b1d51510eaf8326e86e"
+  integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
+
 caniuse-api@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-1.6.1.tgz#b534e7c734c4f81ec5fbe8aca2ad24354b962c6c"
@@ -4163,6 +4300,11 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+chai-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/chai-string/-/chai-string-1.5.0.tgz#0bdb2d8a5f1dbe90bc78ec493c1c1c180dd4d3d2"
+  integrity sha512-sydDC3S3pNAQMYwJrs6dQX0oBQ6KfIPuOZ78n7rocW0eJJlsHPh2t3kwW7xfwYA/1Bf6/arGtSUo16rxR2JFlw==
 
 chai@^4.2.0:
   version "4.3.4"
@@ -4231,6 +4373,30 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
+cheerio-select@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-1.5.0.tgz#faf3daeb31b17c5e1a9dabcee288aaf8aafa5823"
+  integrity sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==
+  dependencies:
+    css-select "^4.1.3"
+    css-what "^5.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
+    domutils "^2.7.0"
+
+cheerio@^1.0.0-rc.9:
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.10.tgz#2ba3dcdfcc26e7956fc1f440e61d51c643379f3e"
+  integrity sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==
+  dependencies:
+    cheerio-select "^1.5.0"
+    dom-serializer "^1.3.2"
+    domhandler "^4.2.0"
+    htmlparser2 "^6.1.0"
+    parse5 "^6.0.1"
+    parse5-htmlparser2-tree-adapter "^6.0.1"
+    tslib "^2.2.0"
+
 chokidar@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.0.tgz#12c0714668c55800f659e262d4962a97faf554a6"
@@ -4245,6 +4411,21 @@ chokidar@3.3.0:
     readdirp "~3.2.0"
   optionalDependencies:
     fsevents "~2.1.1"
+
+chokidar@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
 
 chownr@^1.0.1, chownr@^1.1.1, chownr@^1.1.2, chownr@^1.1.4:
   version "1.1.4"
@@ -4336,6 +4517,15 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone-deep@^4.0.1:
   version "4.0.1"
@@ -4480,10 +4670,20 @@ commander@^2.12.1, commander@^2.20.0, commander@^2.8.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+commander@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
 commander@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
+commander@^8.1.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -4716,6 +4916,19 @@ copy-webpack-plugin@^8.1.1:
     schema-utils "^3.0.0"
     serialize-javascript "^5.0.1"
 
+copyfiles@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-2.4.1.tgz#d2dcff60aaad1015f09d0b66e7f0f1c5cd3c5da5"
+  integrity sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==
+  dependencies:
+    glob "^7.0.5"
+    minimatch "^3.0.3"
+    mkdirp "^1.0.4"
+    noms "0.0.0"
+    through2 "^2.0.1"
+    untildify "^4.0.0"
+    yargs "^16.1.0"
+
 core-js-compat@^3.14.0, core-js-compat@^3.16.0:
   version "3.16.3"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.16.3.tgz#ae12a6e20505a1d79fbd16b6689dfc77fc989114"
@@ -4833,6 +5046,17 @@ css-loader@~0.26.1:
     postcss-modules-values "^1.1.0"
     source-list-map "^0.1.7"
 
+css-select@^4.1.3:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.2.0.tgz#ab28276d3afb00cc05e818bd33eb030f14f57895"
+  integrity sha512-6YVG6hsH9yIb/si3Th/is8Pex7qnVHO6t7q7U6TIUnkQASGbS8tnUDBftnPynLNnuUl/r2+PTd0ekiiq7R0zJw==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^5.1.0"
+    domhandler "^4.3.0"
+    domutils "^2.8.0"
+    nth-check "^2.0.1"
+
 css-selector-tokenizer@^0.7.0:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz#735f26186e67c749aaf275783405cf0661fae8f1"
@@ -4840,6 +5064,11 @@ css-selector-tokenizer@^0.7.0:
   dependencies:
     cssesc "^3.0.0"
     fastparse "^1.1.2"
+
+css-what@^5.0.1, css-what@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.1.0.tgz#3f7b707aadf633baf62c2ceb8579b545bb40f7fe"
+  integrity sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -4963,6 +5192,13 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   dependencies:
     ms "2.1.2"
 
+debug@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@^3.1.0, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
@@ -4992,6 +5228,11 @@ decamelize@^1.1.0, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+decamelize@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
+  integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
 decode-uri-component@^0.2.0:
   version "0.2.0"
@@ -5160,6 +5401,11 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+denodeify@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/denodeify/-/denodeify-1.2.1.tgz#3a36287f5034e699e7577901052c2e6c94251631"
+  integrity sha1-OjYof1A05pnnV3kBBSwubJQlFjE=
+
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -5211,6 +5457,11 @@ diff@3.5.0, diff@^3.4.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
+diff@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
+  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -5260,10 +5511,40 @@ dom-helpers@^5.1.3:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
 
+dom-serializer@^1.0.1, dom-serializer@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
+  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.0"
+    entities "^2.0.0"
+
+domelementtype@^2.0.1, domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+
+domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.0.tgz#16c658c626cf966967e306f966b431f77d4a5626"
+  integrity sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==
+  dependencies:
+    domelementtype "^2.2.0"
+
 dompurify@^2.2.9:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.1.tgz#a47059ca21fd1212d3c8f71fdea6943b8bfbdf6a"
   integrity sha512-xGWt+NHAQS+4tpgbOAI08yxW0Pr256Gu/FNE2frZVTbgrBUn8M7tz7/ktS/LZ2MHeGqz6topj0/xY+y8R5FBFw==
+
+domutils@^2.5.2, domutils@^2.7.0, domutils@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
 
 dot-prop@^4.2.0:
   version "4.2.1"
@@ -5440,10 +5721,20 @@ enquirer@^2.3.5:
   dependencies:
     ansi-colors "^4.1.1"
 
+entities@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
 entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
+entities@~2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 env-paths@^2.2.0:
   version "2.2.1"
@@ -5543,7 +5834,7 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escape-string-regexp@^4.0.0:
+escape-string-regexp@4.0.0, escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
@@ -5654,7 +5945,7 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint@^7.14.0:
+eslint@^7.14.0, eslint@^7.27.0:
   version "7.32.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.32.0.tgz#c6d328a14be3fb08c8d1d21e12c02fdb7a2a812d"
   integrity sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==
@@ -6121,6 +6412,14 @@ find-up@3.0.0, find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-up@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -6165,6 +6464,11 @@ flat@^4.1.0:
   integrity sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==
   dependencies:
     is-buffer "~2.0.3"
+
+flat@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
+  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
 flatted@^3.1.0:
   version "3.2.2"
@@ -6354,6 +6658,11 @@ fsevents@~2.1.1:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
+fsevents@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fstream@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
@@ -6408,7 +6717,7 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -6583,6 +6892,18 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
@@ -6595,7 +6916,7 @@ glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.2.0:
+glob@^7.0.5, glob@^7.0.6, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -6843,7 +7164,7 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
-hosted-git-info@^4.0.1:
+hosted-git-info@^4.0.1, hosted-git-info@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.0.2.tgz#5e425507eede4fea846b7262f0838456c4209961"
   integrity sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==
@@ -6859,6 +7180,16 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+htmlparser2@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
+    entities "^2.0.0"
 
 http-cache-semantics@^3.8.1:
   version "3.8.1"
@@ -6904,6 +7235,15 @@ http-proxy-agent@^2.1.0:
   dependencies:
     agent-base "4"
     debug "3.1.0"
+
+http-proxy-agent@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
+  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
+  dependencies:
+    "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -7032,6 +7372,11 @@ ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
+ignore@^5.1.8:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
+  integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 image-size@~0.5.0:
   version "0.5.5"
@@ -7423,6 +7768,11 @@ is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
 
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -7633,6 +7983,13 @@ js-yaml@3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
+  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
+  dependencies:
+    argparse "^2.0.1"
+
 js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
@@ -7640,6 +7997,13 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 js-yaml@~3.7.0:
   version "3.7.0"
@@ -7785,6 +8149,14 @@ keytar@7.2.0:
     node-addon-api "^3.0.0"
     prebuild-install "^6.0.0"
 
+keytar@^7.7.0:
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/keytar/-/keytar-7.7.0.tgz#3002b106c01631aa79b1aa9ee0493b94179bbbd2"
+  integrity sha512-YEY9HWqThQc5q5xbXbRwsZTh2PJ36OSYRjSv3NN2xf5s5dpLTjEZnC2YikR29OaVybf9nQ0dJ/80i40RS97t/A==
+  dependencies:
+    node-addon-api "^3.0.0"
+    prebuild-install "^6.0.0"
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -7868,6 +8240,11 @@ less@^3.0.3:
     mime "^1.4.1"
     native-request "^1.0.5"
     source-map "~0.6.0"
+
+leven@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
+  integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
 levn@^0.4.1:
   version "0.4.1"
@@ -8003,6 +8380,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -8104,6 +8488,13 @@ log-symbols@3.0.0, log-symbols@^3.0.0:
   integrity sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==
   dependencies:
     chalk "^2.4.2"
+
+log-symbols@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
+  integrity sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
+  dependencies:
+    chalk "^4.0.0"
 
 log-symbols@^2.2.0:
   version "2.2.0"
@@ -8269,6 +8660,17 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-10.0.0.tgz#abfc64f141b1722d663402044e43927f1f50a8dc"
+  integrity sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~2.0.0"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
 markdown-it@^8.4.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
@@ -8418,7 +8820,7 @@ mime-types@^2.1.12, mime-types@^2.1.25, mime-types@^2.1.27, mime-types@~2.1.19, 
   dependencies:
     mime-db "1.49.0"
 
-mime@1.6.0, mime@^1.4.1:
+mime@1.6.0, mime@^1.3.4, mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -8453,7 +8855,7 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -8583,6 +8985,37 @@ mocha@^7.0.0, mocha@^7.1.2:
     yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
 
+mocha@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-8.4.0.tgz#677be88bf15980a3cae03a73e10a0fc3997f0cff"
+  integrity sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==
+  dependencies:
+    "@ungap/promise-all-settled" "1.1.2"
+    ansi-colors "4.1.1"
+    browser-stdout "1.3.1"
+    chokidar "3.5.1"
+    debug "4.3.1"
+    diff "5.0.0"
+    escape-string-regexp "4.0.0"
+    find-up "5.0.0"
+    glob "7.1.6"
+    growl "1.10.5"
+    he "1.2.0"
+    js-yaml "4.0.0"
+    log-symbols "4.0.0"
+    minimatch "3.0.4"
+    ms "2.1.3"
+    nanoid "3.1.20"
+    serialize-javascript "5.0.1"
+    strip-json-comments "3.1.1"
+    supports-color "8.1.1"
+    which "2.0.2"
+    wide-align "1.1.3"
+    workerpool "6.1.0"
+    yargs "16.2.0"
+    yargs-parser "20.2.4"
+    yargs-unparser "2.0.0"
+
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
@@ -8638,7 +9071,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.0.0, ms@^2.1.1:
+ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -8681,6 +9114,11 @@ nan@^2.14.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
+
+nanoid@3.1.20:
+  version "3.1.20"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
+  integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
 
 nanoid@^3.1.23:
   version "3.1.25"
@@ -8844,6 +9282,14 @@ node-releases@^1.1.75:
   version "1.1.75"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.75.tgz#6dd8c876b9897a1b8e5a02de26afa79bb54ebbfe"
   integrity sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==
+
+noms@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/noms/-/noms-0.0.0.tgz#da8ebd9f3af9d6760919b27d9cdc8092a7332859"
+  integrity sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "~1.0.31"
 
 noop-logger@^0.1.1:
   version "0.1.1"
@@ -9057,6 +9503,13 @@ nsfw@^2.1.2:
   integrity sha512-zGPdt32aJ5b1laK9rvgXQmXGAagrx3VkcMt0JePtu6wBfzC1o4xLCM3kq7FxZxUnxyxYhODyBYzpt3H16FhaGA==
   dependencies:
     node-addon-api "*"
+
+nth-check@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
+  integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
+  dependencies:
+    boolbase "^1.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -9299,7 +9752,7 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-osenv@0, osenv@^0.1.4, osenv@^0.1.5:
+osenv@0, osenv@^0.1.3, osenv@^0.1.4, osenv@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   integrity sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==
@@ -9346,7 +9799,7 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.1.0:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -9373,6 +9826,13 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
 
 p-map-series@^1.0.0:
   version "1.0.0"
@@ -9527,6 +9987,13 @@ parse-path@^4.0.0:
     qs "^6.9.4"
     query-string "^6.13.8"
 
+parse-semver@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/parse-semver/-/parse-semver-1.1.1.tgz#9a4afd6df063dc4826f93fba4a99cf223f666cb8"
+  integrity sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=
+  dependencies:
+    semver "^5.1.0"
+
 parse-url@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-6.0.0.tgz#f5dd262a7de9ec00914939220410b66cff09107d"
@@ -9536,6 +10003,18 @@ parse-url@^6.0.0:
     normalize-url "^6.1.0"
     parse-path "^4.0.0"
     protocols "^1.4.0"
+
+parse5-htmlparser2-tree-adapter@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
+  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
+  dependencies:
+    parse5 "^6.0.1"
+
+parse5@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
 parseurl@~1.3.3:
   version "1.3.3"
@@ -9647,7 +10126,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.2.3:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
@@ -10273,6 +10752,13 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.9.1:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.2.tgz#c1431bea37fc5b24c5bdbafa20f16bdf2a4b9ffe"
+  integrity sha512-mSIdjzqznWgfd4pMii7sHtaYF8rx8861hBO80SraY5GT0XQibWZWJSid0avzHGkDIZLImux2S5mXO0Hfct2QCw==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@^6.9.4:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
@@ -10495,7 +10981,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-read@1, read@~1.0.1:
+read@1, read@^1.0.7, read@~1.0.1:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
   integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
@@ -10515,7 +11001,7 @@ read@1, read@~1.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@1.0.x:
+readable-stream@1.0.x, readable-stream@~1.0.31:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
@@ -10560,6 +11046,13 @@ readdirp@~3.2.0:
   integrity sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==
   dependencies:
     picomatch "^2.0.4"
+
+readdirp@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  dependencies:
+    picomatch "^2.2.1"
 
 recast@^0.11.17:
   version "0.11.23"
@@ -10952,7 +11445,7 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sax@~1.2.1:
+sax@>=0.6.0, sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -11004,7 +11497,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -11057,17 +11550,17 @@ serialize-error@^7.0.1:
   dependencies:
     type-fest "^0.13.1"
 
-serialize-javascript@^1.4.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
-
-serialize-javascript@^5.0.1:
+serialize-javascript@5.0.1, serialize-javascript@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
   integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
   dependencies:
     randombytes "^2.1.0"
+
+serialize-javascript@^1.4.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
+  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
 
 serialize-javascript@^6.0.0:
   version "6.0.0"
@@ -11685,7 +12178,7 @@ strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+strip-json-comments@3.1.1, strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -11735,6 +12228,13 @@ supports-color@6.0.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@8.1.1, supports-color@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
+  dependencies:
+    has-flag "^4.0.0"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -11758,13 +12258,6 @@ supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
-  dependencies:
-    has-flag "^4.0.0"
-
-supports-color@^8.0.0:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
@@ -11932,7 +12425,7 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-through2@^2.0.0, through2@^2.0.2:
+through2@^2.0.0, through2@^2.0.1, through2@^2.0.2:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
   integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
@@ -11966,6 +12459,13 @@ tmp@^0.0.33:
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 to-buffer@^1.1.1:
   version "1.1.1"
@@ -12101,7 +12601,7 @@ tslib@^1.10.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.3.1:
+tslib@^2.2.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -12146,7 +12646,7 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-tunnel@^0.0.6:
+tunnel@0.0.6, tunnel@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
   integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
@@ -12205,6 +12705,15 @@ type-is@^1.6.4, type-is@~1.6.17, type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+typed-rest-client@^1.8.4:
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/typed-rest-client/-/typed-rest-client-1.8.6.tgz#d8facd6abd98cbd8ad14cccf056ca5cc306919d7"
+  integrity sha512-xcQpTEAJw2DP7GqVNECh4dD+riS+C1qndXLfBCJ3xk0kqprtGN491P5KlmrDbKdtuW8NEcP/5ChxiJI3S9WYTA==
+  dependencies:
+    qs "^6.9.1"
+    tunnel "0.0.6"
+    underscore "^1.12.1"
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
@@ -12274,6 +12783,11 @@ unbzip2-stream@^1.0.9:
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
+
+underscore@^1.12.1:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.2.tgz#276cea1e8b9722a8dbed0100a407dda572125881"
+  integrity sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -12367,6 +12881,11 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+untildify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
+  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
+
 unzip-stream@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/unzip-stream/-/unzip-stream-0.3.1.tgz#2333b5cd035d29db86fb701ca212cf8517400083"
@@ -12374,6 +12893,22 @@ unzip-stream@^0.3.0:
   dependencies:
     binary "^0.3.0"
     mkdirp "^0.5.1"
+
+unzipper@^0.10.11:
+  version "0.10.11"
+  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.10.11.tgz#0b4991446472cbdb92ee7403909f26c2419c782e"
+  integrity sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==
+  dependencies:
+    big-integer "^1.6.17"
+    binary "~0.3.0"
+    bluebird "~3.4.1"
+    buffer-indexof-polyfill "~1.0.0"
+    duplexer2 "~0.1.4"
+    fstream "^1.0.12"
+    graceful-fs "^4.2.2"
+    listenercount "~1.0.1"
+    readable-stream "~2.3.6"
+    setimmediate "~1.0.4"
 
 unzipper@^0.9.11:
   version "0.9.15"
@@ -12401,6 +12936,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-join@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-1.1.0.tgz#741c6c2f4596c4830d6718460920d0c92202dc78"
+  integrity sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=
 
 url-parse-lax@^3.0.0:
   version "3.0.0"
@@ -12509,6 +13049,35 @@ vhost@^3.0.2:
   resolved "https://registry.yarnpkg.com/vhost/-/vhost-3.0.2.tgz#2fb1decd4c466aa88b0f9341af33dc1aff2478d5"
   integrity sha1-L7HezUxGaqiLD5NBrzPcGv8keNU=
 
+vsce@^1.100.1:
+  version "1.103.1"
+  resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.103.1.tgz#12c9bb4373f0261a8bc85671b86ce7f222f3c694"
+  integrity sha512-98oKQKKRp7J/vTIk1cuzom5cezZpYpRHs3WlySdsrTCrAEipB/HvaPTc4VZ3hGZHzHXS9P5p2L0IllntJeXwiQ==
+  dependencies:
+    azure-devops-node-api "^11.0.1"
+    chalk "^2.4.2"
+    cheerio "^1.0.0-rc.9"
+    commander "^6.1.0"
+    denodeify "^1.2.1"
+    glob "^7.0.6"
+    hosted-git-info "^4.0.2"
+    keytar "^7.7.0"
+    leven "^3.1.0"
+    lodash "^4.17.15"
+    markdown-it "^10.0.0"
+    mime "^1.3.4"
+    minimatch "^3.0.3"
+    osenv "^0.1.3"
+    parse-semver "^1.1.1"
+    read "^1.0.7"
+    semver "^5.1.0"
+    tmp "^0.2.1"
+    typed-rest-client "^1.8.4"
+    url-join "^1.1.0"
+    xml2js "^0.4.23"
+    yauzl "^2.3.1"
+    yazl "^2.2.2"
+
 vscode-debugprotocol@^1.32.0, vscode-debugprotocol@^1.48.0:
   version "1.49.0"
   resolved "https://registry.yarnpkg.com/vscode-debugprotocol/-/vscode-debugprotocol-1.49.0.tgz#1ed0b7d9f2806df24ca9f18bb3485de060f85166"
@@ -12549,6 +13118,16 @@ vscode-ripgrep@^1.2.4:
   dependencies:
     https-proxy-agent "^4.0.0"
     proxy-from-env "^1.1.0"
+
+vscode-test@^1.5.2:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/vscode-test/-/vscode-test-1.6.1.tgz#44254c67036de92b00fdd72f6ace5f1854e1a563"
+  integrity sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==
+  dependencies:
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    rimraf "^3.0.2"
+    unzipper "^0.10.11"
 
 vscode-textmate@^4.0.1, vscode-textmate@^4.4.0:
   version "4.4.0"
@@ -12706,7 +13285,7 @@ which@1, which@1.3.1, which@^1.2.0, which@^1.2.8, which@^1.2.9, which@^1.3.1:
   dependencies:
     isexe "^2.0.0"
 
-which@^2.0.1, which@^2.0.2:
+which@2.0.2, which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
@@ -12750,6 +13329,11 @@ worker-loader@^3.0.8:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
+workerpool@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.0.tgz#a8e038b4c94569596852de7a8ea4228eefdeb37b"
+  integrity sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -12771,6 +13355,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -12850,6 +13443,19 @@ xdg-trashdir@^2.1.1:
     user-home "^2.0.0"
     xdg-basedir "^2.0.0"
 
+xml2js@^0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
@@ -12875,6 +13481,11 @@ xterm@~4.11.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
   integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -12897,6 +13508,11 @@ yargs-parser@13.1.2, yargs-parser@^13.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@20.2.4:
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
 yargs-parser@^11.1.1:
   version "11.1.1"
@@ -12922,7 +13538,7 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^20.2.3:
+yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
@@ -12935,6 +13551,16 @@ yargs-unparser@1.6.0:
     flat "^4.1.0"
     lodash "^4.17.15"
     yargs "^13.3.0"
+
+yargs-unparser@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-2.0.0.tgz#f131f9226911ae5d9ad38c432fe809366c2325eb"
+  integrity sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==
+  dependencies:
+    camelcase "^6.0.0"
+    decamelize "^4.0.0"
+    flat "^5.0.2"
+    is-plain-obj "^2.1.0"
 
 yargs@13.3.2, yargs@^13.3.0:
   version "13.3.2"
@@ -12951,6 +13577,19 @@ yargs@13.3.2, yargs@^13.3.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
+
+yargs@16.2.0, yargs@^16.1.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yargs@^12.0.1:
   version "12.0.5"
@@ -13004,13 +13643,20 @@ yargs@^15.0.2, yargs@^15.3.1:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yauzl@^2.10.0, yauzl@^2.4.2:
+yauzl@^2.10.0, yauzl@^2.3.1, yauzl@^2.4.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
   integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yazl@^2.2.2:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
+  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
+  dependencies:
+    buffer-crc32 "~0.2.3"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
#### What it does

Adds a Javascript library published as an NPM package `@theia/clangd-contexts` for management of the following content in one or more `.clangd` files in a C/C++ VS Code workspace:

- Compilation database (reference to a `compile_commands.json` file)
- Flags to add to what are configured in the compilation database when invoking clang
- Flags to remove from what are configured in the compilation when invoking clang

The usage of this library is demonstrated by two example packages:

- A simple VS Code extension implementing a workspace-wide build configuration selector in the status bar
- A full-featured `clangd-context` CLI tool providing terminal access to all of the library’s capabilities
- A simple example C project with multiple clangd contexts in which to exercise the other examples

The VS Code extension example is deployed into the browser and Electron examples already provided by the Theia CPP Extensions project.

Resolves #142. 

Contributed on behalf of STMicroelectronics.

#### How to test

Build the monorepo, then run the clangd contexts library unit tests with

```console
$ yarn --cwd packages/clangd-contexts test
```

Follow the readme guides in the example packages for details of how to exercise them to perform ad hoc testing of the library:

- examples/clangd-workspace/README.md
- examples/clangd-contexts-ext/README.md
- examples/clangd-contexts-cli/README.md

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
