### PR TITLE
Removed default context menu on right click

### DIFF
--- a/packages/cpp-debug/src/browser/memory-widget/memory-table-widget.tsx
+++ b/packages/cpp-debug/src/browser/memory-widget/memory-table-widget.tsx
@@ -594,6 +594,7 @@ export class MemoryTableWidget extends ReactWidget {
     protected handleTableRightClick = (e: React.MouseEvent): void => this.doHandleTableRightClick(e);
 
     protected doHandleTableRightClick(event: React.MouseEvent): void {
+        event.preventDefault();
         const target = event.target as HTMLElement;
         if (target.classList?.contains('eight-bits')) {
             const { right, top } = target.getBoundingClientRect();

--- a/packages/cpp-debug/src/browser/register-widget/register-table-widget.tsx
+++ b/packages/cpp-debug/src/browser/register-widget/register-table-widget.tsx
@@ -250,6 +250,7 @@ export class RegisterTableWidget extends MemoryTableWidget {
     }
 
     protected doHandleTableRightClick(event: React.MouseEvent): void {
+        event.preventDefault();
         const curTarget = event.currentTarget as HTMLElement;
         if (curTarget.tagName === 'TR') {
             this.update();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR removes the default context menu that is shown when right clicking on the memory table. I think the default context menu is generally removed in Theia.

Before this PR:

![mem-view-ctx-menu gif](https://user-images.githubusercontent.com/8626576/142405732-584f9b99-a249-47e4-a115-4c0cc3bd7434.gif)

After:

![mem-view-no-ctx-menu](https://user-images.githubusercontent.com/8626576/142405721-b9fa46a1-a274-44a5-8515-f18c8e053a06.gif)


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Start a debug session and load a memory address in the memory inspector. After that just right click in the memory table area.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
